### PR TITLE
Issue #9. Allow nested preconditions.

### DIFF
--- a/src/main/java/com/liquigraph/core/api/Liquigraph.java
+++ b/src/main/java/com/liquigraph/core/api/Liquigraph.java
@@ -13,6 +13,4 @@ public final class Liquigraph {
     public void runMigrations(Configuration configuration) {
         migrationRunner.runMigrations(configuration);
     }
-
-
 }

--- a/src/main/java/com/liquigraph/core/api/MigrationRunner.java
+++ b/src/main/java/com/liquigraph/core/api/MigrationRunner.java
@@ -4,6 +4,7 @@ import com.liquigraph.core.configuration.Configuration;
 import com.liquigraph.core.graph.ChangelogReader;
 import com.liquigraph.core.graph.ChangelogWriter;
 import com.liquigraph.core.graph.GraphConnector;
+import com.liquigraph.core.graph.PreconditionExecutor;
 import com.liquigraph.core.model.Changeset;
 import com.liquigraph.core.parser.ChangelogParser;
 import com.liquigraph.core.validation.DeclaredChangesetValidator;
@@ -19,6 +20,7 @@ class MigrationRunner {
     private final ChangelogReader changelogReader;
     private final ChangelogWriter changelogWriter;
     private final ChangelogDiffMaker changelogDiffMaker;
+    private final PreconditionExecutor preconditionExecutor;
     private final DeclaredChangesetValidator declaredChangesetValidator;
     private final PersistedChangesetValidator persistedChangesetValidator;
 
@@ -27,6 +29,7 @@ class MigrationRunner {
                            ChangelogReader changelogReader,
                            ChangelogWriter changelogWriter,
                            ChangelogDiffMaker changelogDiffMaker,
+                           PreconditionExecutor preconditionExecutor,
                            DeclaredChangesetValidator declaredChangesetValidator,
                            PersistedChangesetValidator persistedChangesetValidator) {
 
@@ -35,6 +38,7 @@ class MigrationRunner {
         this.changelogReader = changelogReader;
         this.changelogWriter = changelogWriter;
         this.changelogDiffMaker = changelogDiffMaker;
+        this.preconditionExecutor = preconditionExecutor;
         this.declaredChangesetValidator = declaredChangesetValidator;
         this.persistedChangesetValidator = persistedChangesetValidator;
     }
@@ -53,6 +57,6 @@ class MigrationRunner {
             persistedChangesets
         );
 
-        changelogWriter.write(graphDatabase, changelogsToInsert);
+        changelogWriter.write(graphDatabase, preconditionExecutor, changelogsToInsert);
     }
 }

--- a/src/main/java/com/liquigraph/core/exception/PreconditionSyntaxException.java
+++ b/src/main/java/com/liquigraph/core/exception/PreconditionSyntaxException.java
@@ -1,0 +1,14 @@
+package com.liquigraph.core.exception;
+
+import static java.lang.String.format;
+
+public class PreconditionSyntaxException extends RuntimeException {
+
+    public PreconditionSyntaxException(Throwable cause, String message, Object... arguments) {
+        super(format(message, arguments), cause);
+    }
+
+    public PreconditionSyntaxException(String message, Object... arguments) {
+        super(format(message, arguments));
+    }
+}

--- a/src/main/java/com/liquigraph/core/graph/ChangelogReader.java
+++ b/src/main/java/com/liquigraph/core/graph/ChangelogReader.java
@@ -19,7 +19,7 @@ public class ChangelogReader {
         "RETURN changeset " +
         "ORDER BY exec.order ASC";
 
-    public Collection<Changeset> read(GraphDatabaseService graphDatabase) {
+    public final Collection<Changeset> read(GraphDatabaseService graphDatabase) {
         Collection<Changeset> changesets = newLinkedList();
         ExecutionEngine engine = new ExecutionEngine(graphDatabase);
         try (Transaction transaction = graphDatabase.beginTx();

--- a/src/main/java/com/liquigraph/core/graph/ChangelogWriter.java
+++ b/src/main/java/com/liquigraph/core/graph/ChangelogWriter.java
@@ -1,6 +1,5 @@
 package com.liquigraph.core.graph;
 
-import com.google.common.base.Optional;
 import com.liquigraph.core.exception.PreconditionNotMetException;
 import com.liquigraph.core.model.Changeset;
 import com.liquigraph.core.model.Precondition;
@@ -13,7 +12,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.google.common.base.Optional.absent;
 import static com.google.common.collect.Iterators.getOnlyElement;
 import static java.lang.String.format;
 
@@ -21,32 +19,35 @@ public class ChangelogWriter {
 
     private static final String LATEST_INDEX =
         "MERGE (changelog:__LiquigraphChangelog) " +
-        "WITH changelog " +
-        "OPTIONAL MATCH (changelog)<-[exec:EXECUTED_WITHIN_CHANGELOG]-(:__LiquigraphChangeset)" +
-        "RETURN COALESCE(MAX(exec.order), 0) AS lastIndex";
+            "WITH changelog " +
+            "OPTIONAL MATCH (changelog)<-[exec:EXECUTED_WITHIN_CHANGELOG]-(:__LiquigraphChangeset)" +
+            "RETURN COALESCE(MAX(exec.order), 0) AS lastIndex";
 
     private static final String CHANGESET_UPSERT =
         "MATCH (changelog:__LiquigraphChangelog) " +
-        "MERGE (changelog)<-[:EXECUTED_WITHIN_CHANGELOG {order: {index}}]-(changeset:__LiquigraphChangeset {id: {id}}) " +
-        "ON MATCH SET  changeset.checksum = {checksum}, " +
-        "              changeset.query = {query}" +
-        "ON CREATE SET changeset.author = {author}, " +
-        "              changeset.query = {query}, " +
-        "              changeset.checksum = {checksum}";
+            "MERGE (changelog)<-[:EXECUTED_WITHIN_CHANGELOG {order: {index}}]-(changeset:__LiquigraphChangeset {id: {id}}) " +
+            "ON MATCH SET  changeset.checksum = {checksum}, " +
+            "              changeset.query = {query}" +
+            "ON CREATE SET changeset.author = {author}, " +
+            "              changeset.query = {query}, " +
+            "              changeset.checksum = {checksum}";
 
-    public void write(GraphDatabaseService graphDatabase, Collection<Changeset> changelogsToInsert) {
-        try (Transaction transaction = graphDatabase.beginTx()) {
-            ExecutionEngine cypherEngine = new ExecutionEngine(graphDatabase);
-            long index = latestPersistedIndex(cypherEngine) + 1L;
 
-            for (Changeset changeset : changelogsToInsert) {
+    public final void write(GraphDatabaseService graphDatabase,
+                      PreconditionExecutor preconditionExecutor,
+                      Collection<Changeset> changelogsToInsert) {
+
+        ExecutionEngine cypherEngine = new ExecutionEngine(graphDatabase);
+        long index = latestPersistedIndex(graphDatabase) + 1L;
+
+        for (Changeset changeset : changelogsToInsert) {
+            try (Transaction transaction = graphDatabase.beginTx()) {
                 Precondition precondition = changeset.getPrecondition();
-                PreconditionResult result = executePrecondition(cypherEngine, precondition).orNull();
+                PreconditionResult result = preconditionExecutor.executePrecondition(cypherEngine, precondition).orNull();
                 if (result == null || result.executedSuccessfully()) {
                     cypherEngine.execute(changeset.getQuery());
                     upsertChangeset(cypherEngine, index, changeset);
-                }
-                else {
+                } else {
                     switch (result.errorPolicy()) {
                         case CONTINUE:
                             continue;
@@ -56,7 +57,7 @@ public class ChangelogWriter {
                         case FAIL:
                             throw new PreconditionNotMetException(
                                 format(
-                                    "Changeset <%s>: precondition query <%s> failed with policy <%s>. Aborting.",
+                                    "Changeset <%s>: precondition query %s failed with policy <%s>. Aborting.",
                                     changeset.getId(),
                                     precondition.getQuery(),
                                     precondition.getPolicy()
@@ -64,10 +65,9 @@ public class ChangelogWriter {
                             );
                     }
                 }
-                index++;
+                transaction.success();
             }
-
-            transaction.success();
+            index++;
         }
     }
 
@@ -75,9 +75,13 @@ public class ChangelogWriter {
         cypherEngine.execute(CHANGESET_UPSERT, parameters(changeset, index));
     }
 
-    private long latestPersistedIndex(ExecutionEngine cypherEngine) {
-        try (ResourceIterator<Long> results = cypherEngine.execute(LATEST_INDEX).columnAs("lastIndex")) {
-            return getOnlyElement(results);
+    private long latestPersistedIndex(GraphDatabaseService graphDb) {
+        try (Transaction transaction = graphDb.beginTx();
+             ResourceIterator<Long> results = new ExecutionEngine(graphDb).execute(LATEST_INDEX).columnAs("lastIndex")) {
+
+            Long result = getOnlyElement(results);
+            transaction.success();
+            return result;
         }
     }
 
@@ -91,16 +95,4 @@ public class ChangelogWriter {
         return parameters;
     }
 
-    private Optional<PreconditionResult> executePrecondition(ExecutionEngine cypherEngine, Precondition precondition) {
-        if (precondition == null) {
-            return absent();
-        }
-        return Optional.of(applyPrecondition(cypherEngine, precondition));
-    }
-
-    private PreconditionResult applyPrecondition(ExecutionEngine cypherEngine, Precondition precondition) {
-        try (ResourceIterator<Boolean> results = cypherEngine.execute(precondition.getQuery()).columnAs("result")) {
-            return new PreconditionResult(precondition.getPolicy(), getOnlyElement(results));
-        }
-    }
 }

--- a/src/main/java/com/liquigraph/core/graph/GraphConnector.java
+++ b/src/main/java/com/liquigraph/core/graph/GraphConnector.java
@@ -13,7 +13,7 @@ import static java.lang.String.format;
 
 public class GraphConnector {
 
-    public GraphDatabaseService connect(Configuration configuration) {
+    public final GraphDatabaseService connect(Configuration configuration) {
         String uri = configuration.uri();
         if (uri.startsWith("file://")) {
             return embeddedGraphDatabase(uri);

--- a/src/main/java/com/liquigraph/core/graph/PreconditionExecutor.java
+++ b/src/main/java/com/liquigraph/core/graph/PreconditionExecutor.java
@@ -1,0 +1,62 @@
+package com.liquigraph.core.graph;
+
+import com.google.common.base.Optional;
+import com.liquigraph.core.exception.PreconditionSyntaxException;
+import com.liquigraph.core.model.*;
+import org.neo4j.cypher.EntityNotFoundException;
+import org.neo4j.cypher.SyntaxException;
+import org.neo4j.cypher.javacompat.ExecutionEngine;
+import org.neo4j.graphdb.ResourceIterator;
+
+import static com.google.common.base.Optional.absent;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterators.getOnlyElement;
+import static java.lang.String.format;
+
+public class PreconditionExecutor {
+
+    public final Optional<PreconditionResult> executePrecondition(ExecutionEngine cypherEngine, Precondition precondition) {
+        if (precondition == null) {
+            return absent();
+        }
+        checkArgument(cypherEngine != null, "ExecutionEngine should not be null");
+        PreconditionResult result = new PreconditionResult(
+            precondition.getPolicy(),
+            applyPrecondition(cypherEngine, precondition.getQuery())
+        );
+        return Optional.of(result);
+    }
+
+    private boolean applyPrecondition(ExecutionEngine cypherEngine, PreconditionQuery query) {
+        if (query instanceof SimpleQuery) {
+            SimpleQuery simpleQuery = (SimpleQuery) query;
+            return execute(cypherEngine, simpleQuery.getQuery());
+        }
+        if (query instanceof AndQuery || query instanceof OrQuery) {
+            CompoundQuery compoundQuery = (CompoundQuery) query;
+            boolean firstResult = applyPrecondition(cypherEngine, compoundQuery.getFirstQuery());
+            PreconditionQuery secondQuery = compoundQuery.getSecondQuery();
+            return query instanceof OrQuery ?
+                   firstResult || applyPrecondition(cypherEngine, secondQuery) :
+                   firstResult && applyPrecondition(cypherEngine, secondQuery);
+        }
+        throw new IllegalArgumentException(format("Unsupported query type <%s>", query.getClass().getName()));
+    }
+
+    private boolean execute(ExecutionEngine cypherEngine, String query) {
+        try (ResourceIterator<Boolean> results = cypherEngine.execute(query).columnAs("result")) {
+            return getOnlyElement(results);
+        }
+        catch (EntityNotFoundException e) {
+            throw new PreconditionSyntaxException("%n\tQuery <%s> should yield exactly one column named or aliased 'result'.", query);
+        }
+        catch (SyntaxException e) {
+            throw new PreconditionSyntaxException(
+                e.getCause(),
+                "%n\tQuery <%s> is invalid. Please check again its syntax.%n\tMore details:\n%s",
+                query,
+                e.getMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/liquigraph/core/model/AndQuery.java
+++ b/src/main/java/com/liquigraph/core/model/AndQuery.java
@@ -1,0 +1,66 @@
+package com.liquigraph.core.model;
+
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlElementRefs;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.liquigraph.core.model.CompoundQueries.checkQueryListState;
+import static java.lang.String.format;
+
+@XmlSeeAlso(PreconditionQuery.class)
+@XmlRootElement(name = "and")
+public class AndQuery implements CompoundQuery {
+
+    private List<PreconditionQuery> preconditionQueries = newArrayList();
+
+    @XmlElementRefs({
+        @XmlElementRef(name = "and", type = AndQuery.class),
+        @XmlElementRef(name = "or", type = OrQuery.class),
+        @XmlElementRef(name = "query", type = SimpleQuery.class)
+    })
+    public List<PreconditionQuery> getPreconditionQueries() {
+        return preconditionQueries;
+    }
+
+    public void setPreconditionQueries(List<PreconditionQuery> preconditionQueries) {
+        this.preconditionQueries = preconditionQueries;
+    }
+
+    @Override
+    public PreconditionQuery getFirstQuery() {
+        checkQueryListState(preconditionQueries);
+        return preconditionQueries.get(0);
+    }
+
+    @Override
+    public PreconditionQuery getSecondQuery() {
+        checkQueryListState(preconditionQueries);
+        return preconditionQueries.get(1);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(preconditionQueries);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final AndQuery other = (AndQuery) obj;
+        return Objects.equals(this.preconditionQueries, other.preconditionQueries);
+    }
+
+    @Override
+    public String toString() {
+        return format("<%s> AND <%s>", getFirstQuery(), getSecondQuery());
+    }
+}

--- a/src/main/java/com/liquigraph/core/model/Changelog.java
+++ b/src/main/java/com/liquigraph/core/model/Changelog.java
@@ -1,7 +1,5 @@
 package com.liquigraph.core.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Collection;
@@ -9,7 +7,6 @@ import java.util.Collection;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newArrayList;
 
-@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlRootElement(name = "changelog")
 public class Changelog {
 

--- a/src/main/java/com/liquigraph/core/model/Changeset.java
+++ b/src/main/java/com/liquigraph/core/model/Changeset.java
@@ -4,7 +4,9 @@ package com.liquigraph.core.model;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -12,7 +14,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.liquigraph.core.model.Checksums.checksum;
 
-@XmlAccessorType(XmlAccessType.PROPERTY)
 public class Changeset {
 
     private String id;

--- a/src/main/java/com/liquigraph/core/model/CompoundQueries.java
+++ b/src/main/java/com/liquigraph/core/model/CompoundQueries.java
@@ -1,0 +1,12 @@
+package com.liquigraph.core.model;
+
+import java.util.Collection;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class CompoundQueries {
+
+    public static void checkQueryListState(Collection<PreconditionQuery> queries) {
+        checkState(queries.size() == 2);
+    }
+}

--- a/src/main/java/com/liquigraph/core/model/CompoundQuery.java
+++ b/src/main/java/com/liquigraph/core/model/CompoundQuery.java
@@ -1,0 +1,7 @@
+package com.liquigraph.core.model;
+
+public interface CompoundQuery extends PreconditionQuery {
+
+    public PreconditionQuery getFirstQuery();
+    public PreconditionQuery getSecondQuery();
+}

--- a/src/main/java/com/liquigraph/core/model/OrQuery.java
+++ b/src/main/java/com/liquigraph/core/model/OrQuery.java
@@ -1,0 +1,66 @@
+package com.liquigraph.core.model;
+
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlElementRefs;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.liquigraph.core.model.CompoundQueries.checkQueryListState;
+import static java.lang.String.format;
+
+@XmlSeeAlso(PreconditionQuery.class)
+@XmlRootElement(name = "or")
+public class OrQuery implements CompoundQuery {
+
+    private List<PreconditionQuery> preconditionQueries = newArrayList();
+
+    @XmlElementRefs({
+        @XmlElementRef(name = "and", type = AndQuery.class),
+        @XmlElementRef(name = "or", type = OrQuery.class),
+        @XmlElementRef(name = "query", type = SimpleQuery.class)
+    })
+    public List<PreconditionQuery> getPreconditionQueries() {
+        return preconditionQueries;
+    }
+
+    public void setPreconditionQueries(List<PreconditionQuery> preconditionQueries) {
+        this.preconditionQueries = preconditionQueries;
+    }
+
+    @Override
+    public PreconditionQuery getFirstQuery() {
+        checkQueryListState(preconditionQueries);
+        return preconditionQueries.get(0);
+    }
+
+    @Override
+    public PreconditionQuery getSecondQuery() {
+        checkQueryListState(preconditionQueries);
+        return preconditionQueries.get(1);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(preconditionQueries);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final OrQuery other = (OrQuery) obj;
+        return Objects.equals(this.preconditionQueries, other.preconditionQueries);
+    }
+
+    @Override
+    public String toString() {
+        return format("<%s> OR <%s>", getFirstQuery(), getSecondQuery());
+    }
+}

--- a/src/main/java/com/liquigraph/core/model/Precondition.java
+++ b/src/main/java/com/liquigraph/core/model/Precondition.java
@@ -1,17 +1,15 @@
 package com.liquigraph.core.model;
 
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlElementRefs;
 import java.util.Objects;
 
-@XmlAccessorType(XmlAccessType.PROPERTY)
 public class Precondition {
 
     private PreconditionErrorPolicy policy;
-    private String query;
+    private PreconditionQuery query;
 
     @XmlAttribute(name = "if-not-met", required = true)
     public PreconditionErrorPolicy getPolicy() {
@@ -22,12 +20,16 @@ public class Precondition {
         this.policy = policy;
     }
 
-    @XmlElement(name = "query", required = true)
-    public String getQuery() {
+    @XmlElementRefs({
+        @XmlElementRef(name = "and", type = AndQuery.class),
+        @XmlElementRef(name = "or", type = OrQuery.class),
+        @XmlElementRef(name = "query", type = SimpleQuery.class)
+    })
+    public PreconditionQuery getQuery() {
         return query;
     }
 
-    public void setQuery(String query) {
+    public void setQuery(PreconditionQuery query) {
         this.query = query;
     }
 
@@ -51,8 +53,8 @@ public class Precondition {
     @Override
     public String toString() {
         return "Precondition{" +
-            "policy=" + policy +
-            ", query='" + query + '\'' +
-            '}';
+                "policy=" + policy +
+                ", query='" + query + '\'' +
+                '}';
     }
 }

--- a/src/main/java/com/liquigraph/core/model/PreconditionQuery.java
+++ b/src/main/java/com/liquigraph/core/model/PreconditionQuery.java
@@ -1,0 +1,8 @@
+package com.liquigraph.core.model;
+
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlTransient;
+
+@XmlTransient
+@XmlSeeAlso({SimpleQuery.class, AndQuery.class, OrQuery.class})
+public interface PreconditionQuery {}

--- a/src/main/java/com/liquigraph/core/model/SimpleQuery.java
+++ b/src/main/java/com/liquigraph/core/model/SimpleQuery.java
@@ -1,0 +1,46 @@
+package com.liquigraph.core.model;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlValue;
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+@XmlSeeAlso(PreconditionQuery.class)
+@XmlRootElement(name = "query")
+public class SimpleQuery implements PreconditionQuery {
+
+    private String query;
+
+    @XmlValue
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(query);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final SimpleQuery other = (SimpleQuery) obj;
+        return Objects.equals(this.query, other.query);
+    }
+
+    @Override
+    public String toString() {
+        return format("<%s>", query);
+    }
+}

--- a/src/main/java/com/liquigraph/core/model/package-info.java
+++ b/src/main/java/com/liquigraph/core/model/package-info.java
@@ -1,0 +1,6 @@
+@XmlAccessorType(XmlAccessType.PROPERTY)
+package com.liquigraph.core.model;
+
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/src/test/java/com/liquigraph/core/graph/ChangelogReaderTest.java
+++ b/src/test/java/com/liquigraph/core/graph/ChangelogReaderTest.java
@@ -1,6 +1,5 @@
 package com.liquigraph.core.graph;
 
-import com.liquigraph.core.graph.ChangelogReader;
 import com.liquigraph.core.model.Changeset;
 import com.liquigraph.core.rules.EmbeddedGraphDatabaseRule;
 import org.junit.Rule;

--- a/src/test/java/com/liquigraph/core/graph/ChangelogWriterTest.java
+++ b/src/test/java/com/liquigraph/core/graph/ChangelogWriterTest.java
@@ -4,6 +4,7 @@ import com.liquigraph.core.exception.PreconditionNotMetException;
 import com.liquigraph.core.model.Changeset;
 import com.liquigraph.core.model.Precondition;
 import com.liquigraph.core.model.PreconditionErrorPolicy;
+import com.liquigraph.core.model.SimpleQuery;
 import com.liquigraph.core.rules.EmbeddedGraphDatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,7 +32,11 @@ public class ChangelogWriterTest {
 
     @Test
     public void persists_changesets_in_graph() {
-        writer.write(graph.graphDatabase(), newArrayList(changeset("identifier", "fbiville", "CREATE (n: SomeNode {text:'yeah'})")));
+        writer.write(
+            graph.graphDatabase(),
+            new PreconditionExecutor(),
+            newArrayList(changeset("identifier", "fbiville", "CREATE (n: SomeNode {text:'yeah'})"))
+        );
 
         try (Transaction transaction = graph.graphDatabase().beginTx();
             ResourceIterator<Map<String, Object>> iterator = graph.cypherEngine().execute(
@@ -60,7 +65,11 @@ public class ChangelogWriterTest {
         Precondition precondition = precondition(PreconditionErrorPolicy.FAIL, "RETURN true AS result");
         Changeset changeset = changeset("identifier", "fbiville", "CREATE (n: SomeNode {text:'yeah'})", precondition);
 
-        writer.write(graph.graphDatabase(), newArrayList(changeset));
+        writer.write(
+            graph.graphDatabase(),
+            new PreconditionExecutor(),
+            newArrayList(changeset)
+        );
 
         try (Transaction transaction = graph.graphDatabase().beginTx();
              ResourceIterator<Map<String, Object>> iterator = graph.cypherEngine().execute(
@@ -92,7 +101,11 @@ public class ChangelogWriterTest {
         Precondition precondition = precondition(PreconditionErrorPolicy.FAIL, "RETURN false AS result");
         Changeset changeset = changeset("identifier", "fbiville", "CREATE (n: SomeNode {text:'yeah'})", precondition);
 
-        writer.write(graph.graphDatabase(), newArrayList(changeset));
+        writer.write(
+            graph.graphDatabase(),
+            new PreconditionExecutor(),
+            newArrayList(changeset)
+        );
     }
 
     @Test
@@ -100,7 +113,11 @@ public class ChangelogWriterTest {
         Precondition precondition = precondition(PreconditionErrorPolicy.CONTINUE, "RETURN false AS result");
         Changeset changeset = changeset("identifier", "fbiville", "CREATE (n: SomeNode {text:'yeah'})", precondition);
 
-        writer.write(graph.graphDatabase(), newArrayList(changeset));
+        writer.write(
+            graph.graphDatabase(),
+            new PreconditionExecutor(),
+            newArrayList(changeset)
+        );
 
         try (Transaction transaction = graph.graphDatabase().beginTx();
              ResourceIterator<Map<String, Object>> iterator = graph.cypherEngine().execute(
@@ -119,7 +136,11 @@ public class ChangelogWriterTest {
         Precondition precondition = precondition(PreconditionErrorPolicy.MARK_AS_EXECUTED, "RETURN false AS result");
         Changeset changeset = changeset("identifier", "fbiville", "CREATE (n: SomeNode {text:'yeah'})", precondition);
 
-        writer.write(graph.graphDatabase(), newArrayList(changeset));
+        writer.write(
+            graph.graphDatabase(),
+            new PreconditionExecutor(),
+            newArrayList(changeset)
+        );
 
         try (Transaction transaction = graph.graphDatabase().beginTx();
              ResourceIterator<Map<String, Object>> iterator = graph.cypherEngine().execute(
@@ -145,7 +166,9 @@ public class ChangelogWriterTest {
     private Precondition precondition(PreconditionErrorPolicy policy, String query) {
         Precondition precondition = new Precondition();
         precondition.setPolicy(policy);
-        precondition.setQuery(query);
+        SimpleQuery simpleQuery = new SimpleQuery();
+        simpleQuery.setQuery(query);
+        precondition.setQuery(simpleQuery);
         return precondition;
     }
 

--- a/src/test/java/com/liquigraph/core/graph/PreconditionExecutorTest.java
+++ b/src/test/java/com/liquigraph/core/graph/PreconditionExecutorTest.java
@@ -1,0 +1,181 @@
+package com.liquigraph.core.graph;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.liquigraph.core.exception.PreconditionSyntaxException;
+import com.liquigraph.core.model.*;
+import com.liquigraph.core.rules.EmbeddedGraphDatabaseRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.Transaction;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PreconditionExecutorTest {
+
+    @Rule
+    public EmbeddedGraphDatabaseRule graphDatabaseRule = new EmbeddedGraphDatabaseRule();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private PreconditionExecutor executor = new PreconditionExecutor();
+
+    @Test
+    public void returns_no_result_when_precondition_is_null() {
+        Optional<PreconditionResult> result = executor.executePrecondition(graphDatabaseRule.cypherEngine(), null);
+
+        assertThat(result).isEqualTo(Optional.absent());
+    }
+
+    @Test
+    public void fails_with_invalid_cypher_query() {
+        thrown.expect(PreconditionSyntaxException.class);
+        thrown.expectMessage("\tQuery <toto> is invalid. Please check again its syntax.\n" +
+            "\tMore details:\n" +
+            "Invalid input 't': expected SingleStatement (line 1, column 1)\n" +
+            "\"toto\"\n" +
+            " ^");
+
+        try (Transaction transaction = graphDatabaseRule.graphDatabase().beginTx()) {
+            executor.executePrecondition(
+                graphDatabaseRule.cypherEngine(),
+                simplePrecondition(PreconditionErrorPolicy.MARK_AS_EXECUTED, "toto")
+            );
+        }
+    }
+
+    @Test
+    public void fails_with_badly_named_precondition_result_column() {
+        thrown.expect(PreconditionSyntaxException.class);
+        thrown.expectMessage("Query <RETURN true> should yield exactly one column named or aliased 'result'.");
+
+        try (Transaction transaction = graphDatabaseRule.graphDatabase().beginTx()) {
+            executor.executePrecondition(
+                graphDatabaseRule.cypherEngine(),
+                simplePrecondition(PreconditionErrorPolicy.MARK_AS_EXECUTED, "RETURN true")
+            );
+        }
+    }
+
+    @Test
+    public void executes_simple_precondition() {
+        try (Transaction transaction = graphDatabaseRule.graphDatabase().beginTx()) {
+            Optional<PreconditionResult> maybeResult = executor.executePrecondition(
+                graphDatabaseRule.cypherEngine(),
+                simplePrecondition(PreconditionErrorPolicy.MARK_AS_EXECUTED, "RETURN true AS result")
+            );
+
+            PreconditionResult result = maybeResult.get();
+            assertThat(result.errorPolicy()).isEqualTo(PreconditionErrorPolicy.MARK_AS_EXECUTED);
+            assertThat(result.executedSuccessfully()).isTrue();
+            transaction.success();
+        }
+    }
+
+    @Test
+    public void executes_nested_and_precondition_queries() {
+        try (Transaction transaction = graphDatabaseRule.graphDatabase().beginTx()) {
+            Optional<PreconditionResult> maybeResult = executor.executePrecondition(
+                graphDatabaseRule.cypherEngine(),
+                andPrecondition(PreconditionErrorPolicy.FAIL, "RETURN true AS result", "RETURN false AS result")
+            );
+
+            PreconditionResult result = maybeResult.get();
+            assertThat(result.errorPolicy()).isEqualTo(PreconditionErrorPolicy.FAIL);
+            assertThat(result.executedSuccessfully()).isFalse();
+            transaction.success();
+        }
+    }
+
+    @Test
+    public void executes_nested_or_precondition_queries() {
+        try (Transaction transaction = graphDatabaseRule.graphDatabase().beginTx()) {
+            Optional<PreconditionResult> maybeResult = executor.executePrecondition(
+                graphDatabaseRule.cypherEngine(),
+                orPrecondition(PreconditionErrorPolicy.CONTINUE, "RETURN true AS result", "RETURN false AS result")
+            );
+
+            PreconditionResult result = maybeResult.get();
+            assertThat(result.errorPolicy()).isEqualTo(PreconditionErrorPolicy.CONTINUE);
+            assertThat(result.executedSuccessfully()).isTrue();
+            transaction.success();
+        }
+    }
+
+    @Test
+    public void executes_nested_mixed_precondition_queries_like_a_charm() {
+        Precondition precondition = precondition(PreconditionErrorPolicy.MARK_AS_EXECUTED);
+        AndQuery andQuery = new AndQuery();
+        andQuery.setPreconditionQueries(newArrayList(
+            orPreconditionQuery("RETURN false AS result", "RETURN true AS result"),
+            simplePreconditionQuery("RETURN true AS result")
+        ));
+        precondition.setQuery(andQuery);
+
+        try (Transaction transaction = graphDatabaseRule.graphDatabase().beginTx()) {
+            Optional<PreconditionResult> maybeResult = executor.executePrecondition(
+                graphDatabaseRule.cypherEngine(),
+                precondition
+            );
+
+            PreconditionResult result = maybeResult.get();
+            assertThat(result.errorPolicy()).isEqualTo(PreconditionErrorPolicy.MARK_AS_EXECUTED);
+            assertThat(result.executedSuccessfully()).isTrue();
+            transaction.success();
+        }
+    }
+
+    private Precondition simplePrecondition(PreconditionErrorPolicy fail, String query) {
+        SimpleQuery simpleQuery = simplePreconditionQuery(query);
+        Precondition precondition = precondition(fail);
+        precondition.setQuery(simpleQuery);
+        return precondition;
+    }
+
+    private Precondition andPrecondition(PreconditionErrorPolicy errorPolicy, String firstQuery, String secondQuery) {
+        Precondition precondition = precondition(errorPolicy);
+        precondition.setQuery(andPreconditionQuery(firstQuery, secondQuery));
+        return precondition;
+    }
+
+    private Precondition orPrecondition(PreconditionErrorPolicy errorPolicy, String firstQuery, String secondQuery) {
+        Precondition precondition = precondition(errorPolicy);
+        precondition.setQuery(orPreconditionQuery(firstQuery, secondQuery));
+        return precondition;
+    }
+
+    private AndQuery andPreconditionQuery(String firstQuery, String secondQuery) {
+        AndQuery andQuery = new AndQuery();
+        andQuery.setPreconditionQueries(simpleQueries(firstQuery, secondQuery));
+        return andQuery;
+    }
+
+    private OrQuery orPreconditionQuery(String firstQuery, String secondQuery) {
+        OrQuery orQuery = new OrQuery();
+        orQuery.setPreconditionQueries(simpleQueries(firstQuery, secondQuery));
+        return orQuery;
+    }
+
+    private List<PreconditionQuery> simpleQueries(String firstQuery, String secondQuery) {
+        return Lists.<PreconditionQuery>newArrayList(
+            simplePreconditionQuery(firstQuery), simplePreconditionQuery(secondQuery)
+        );
+    }
+
+    private Precondition precondition(PreconditionErrorPolicy policy) {
+        Precondition precondition = new Precondition();
+        precondition.setPolicy(policy);
+        return precondition;
+    }
+
+    private SimpleQuery simplePreconditionQuery(String query) {
+        SimpleQuery simpleQuery = new SimpleQuery();
+        simpleQuery.setQuery(query);
+        return simpleQuery;
+    }
+}

--- a/src/test/java/com/liquigraph/core/parser/ChangelogParserTest.java
+++ b/src/test/java/com/liquigraph/core/parser/ChangelogParserTest.java
@@ -1,8 +1,6 @@
 package com.liquigraph.core.parser;
 
-import com.liquigraph.core.model.Changeset;
-import com.liquigraph.core.model.Precondition;
-import com.liquigraph.core.model.PreconditionErrorPolicy;
+import com.liquigraph.core.model.*;
 import org.assertj.core.api.iterable.Extractor;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -94,10 +92,25 @@ public class ChangelogParserTest {
             );
     }
 
+    @Test
+    public void parses_changelog_with_nested_preconditions() {
+        Collection<Changeset> changesets = parser.parse("/changelog-with-nested-preconditions.xml");
+
+        assertThat(changesets).extracting("precondition.query.class")
+            .containsExactly(
+                SimpleQuery.class,
+                AndQuery.class,
+                OrQuery.class,
+                OrQuery.class
+            );
+    }
+
     private Precondition precondition(PreconditionErrorPolicy errorPolicy, String query) {
         Precondition precondition = new Precondition();
         precondition.setPolicy(errorPolicy);
-        precondition.setQuery(query);
+        SimpleQuery simpleQuery = new SimpleQuery();
+        simpleQuery.setQuery(query);
+        precondition.setQuery(simpleQuery);
         return precondition;
     }
 }

--- a/src/test/resources/changelog-with-nested-preconditions.xml
+++ b/src/test/resources/changelog-with-nested-preconditions.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changelog>
+    <changeset id="first-changelog" author="fbiville">
+        <precondition if-not-met="FAIL">
+            <query><![CDATA[MATCH npre RETURN npre]]></query>
+        </precondition>
+        <query><![CDATA[MATCH n RETURN n]]></query>
+    </changeset>
+    <changeset id="second-changelog" author="team">
+        <precondition if-not-met="MARK_AS_EXECUTED">
+            <and>
+                <query><![CDATA[MATCH mpre1 RETURN mpre1]]></query>
+                <query><![CDATA[MATCH mpre2 RETURN mpre2]]></query>
+            </and>
+        </precondition>
+        <query><![CDATA[MATCH m RETURN m]]></query>
+    </changeset>
+    <changeset id="third-changelog" author="team">
+        <precondition if-not-met="MARK_AS_EXECUTED">
+            <or>
+                <query><![CDATA[MATCH mpre1 RETURN mpre1]]></query>
+                <query><![CDATA[MATCH mpre2 RETURN mpre2]]></query>
+            </or>
+        </precondition>
+        <query><![CDATA[MATCH m RETURN m]]></query>
+    </changeset>
+    <changeset id="fourth-changelog" author="fbiville">
+        <precondition if-not-met="FAIL">
+            <or>
+                <and>
+                    <query><![CDATA[MATCH npre1 RETURN npre1]]></query>
+                    <query><![CDATA[MATCH npre2 RETURN npre2]]></query>
+                </and>
+                <query><![CDATA[MATCH npre RETURN npre]]></query>
+            </or>
+        </precondition>
+        <query><![CDATA[MATCH m]]></query>
+    </changeset>
+</changelog>


### PR DESCRIPTION
Precondition executor is now more thoroughly tested, especially
with corner cases (invalid syntax, no column 'result').

Finally, a slight change on transaction management has been done:
there is no global transaction anymore, but one per changeset, as
it was initially intended.
