### PR TITLE
Fix dagger2 pom.xml

### DIFF
--- a/liquigraph-examples/dagger2/pom.xml
+++ b/liquigraph-examples/dagger2/pom.xml
@@ -6,6 +6,7 @@
         <groupId>org.liquigraph</groupId>
         <artifactId>liquigraph-parent</artifactId>
         <version>3.0.2-SNAPSHOT</version>
+	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>liquigraph-dagger2</artifactId>


### PR DESCRIPTION
The pom was missing a relative path setting as it's more than one
subdirectory under the root directory.