### PR TITLE
sonarqube integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,17 @@ env:
     - NEO_VERSION=3.1.2
       WITH_DOCKER=true
       EXTRA_PROFILES=-Pwith-neo4j-io
+addons:
+  sonarqube:
+    organization: ${SONAR_ORGANIZATION}
+    token:
+      secure: ${SONAR_TOKEN}
+    github_token:
+      secure: ${GITHUB_TOKEN}
 before_script:
-script: build/run.sh
+script:
+  - build/run.sh
+  - sonar-scanner
 install: true
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.host.url=http://sonarqube.com
+# must be unique in a given SonarQube instance
+sonar.projectKey=liquigraph
+# this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
+sonar.projectName=Liquigraph
+sonar.projectVersion=1.0
+
+# Set modules IDs
+sonar.modules=liquigraph-cli,liquigraph-core,liquigraph-maven-plugin,liquigraph-spring-boot-starter,liquigraph-examples
+
+# Modules inherit properties set at parent level
+sonar.sources=src
+sonar.sourceEncoding=UTF-8
+sonar.language=java
+
+liquigraph-examples.sonar.sources=dagger2/src


### PR DESCRIPTION
This is an attempt to enable the use of SonarQube.com for quality analysis #116.
To set the values for the needed environment variables in Travis follow this [documentation](https://docs.travis-ci.com/user/sonarqube/#Inspecting-code-with-the-SonarQube-Scanner):
- `SONAR_ORGANIZATION`: name of the organisation in Sonarqube
- `SONAR_TOKEN`: the token generated in Sonarqube
- `GITHUB_TOKEN`: (to be able to run sonar on pull requests) github personal access token [doc](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)