### PR TITLE
#228 - Fixing log level for postcondition execution

### DIFF
--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphWriter.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphWriter.java
@@ -98,7 +98,7 @@ public class ChangelogGraphWriter implements ChangelogWriter {
 
             boolean postConditionApplies;
             do {
-                LOGGER.error("Executing postcondition of changeset ID {} by {}", changeset.getId(), changeset.getAuthor());
+                LOGGER.info("Executing postcondition of changeset ID {} by {}", changeset.getId(), changeset.getAuthor());
                 executeChangesetQueries(changeset.getQueries());
 
                 Postcondition postcondition = changeset.getPostcondition();


### PR DESCRIPTION
Change the log level from ERROR to INFO when postconditions run.