### PR TITLE
Do not add username and password to JDBC URI

### DIFF
--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByUri.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByUri.java
@@ -16,9 +16,7 @@
 package org.liquigraph.core.configuration;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -31,56 +29,61 @@ public class ConnectionConfigurationByUri implements ConnectionConfiguration {
     private final String uri;
     private final Optional<String> username;
     private final Optional<String> password;
-    private final Function<String, Connection> driverManager;
+    private final UriConnectionProvider connectionProvider;
 
     public ConnectionConfigurationByUri(String uri,
                                         Optional<String> username,
                                         Optional<String> password) {
 
-        this(uri, username, password, UriToConnectionFunction.INSTANCE);
+        this(uri, username, password, DefaultUriConnectionProvider.INSTANCE);
     }
 
     @VisibleForTesting
     ConnectionConfigurationByUri(String uri,
                                  Optional<String> username,
                                  Optional<String> password,
-                                 Function<String, Connection> driverManager) {
+                                 UriConnectionProvider connectionProvider) {
 
         this.uri = uri;
         this.username = username;
         this.password = password;
-        this.driverManager = driverManager;
+        this.connectionProvider = connectionProvider;
     }
 
     @Override
     public Connection get() {
-        return driverManager.apply(uri());
-    }
-
-    private String uri() {
-        if (!username.isPresent()) {
-            return uri;
+        if (username.isPresent()) {
+            return connectionProvider.getConnection(uri, username.get(), password.or(""));
         }
-        return authenticatedUri();
+        return connectionProvider.getConnection(uri);
+
     }
 
-    private String authenticatedUri() {
-        String firstDelimiter = uri.contains("?") ? "," : "?";
-        return uri
-                + firstDelimiter + "user=" + username.get()
-                + ",password=" + password.or("");
-    }
-
-    private enum UriToConnectionFunction implements Function<String, Connection> {
+    private enum DefaultUriConnectionProvider implements UriConnectionProvider {
         INSTANCE;
 
         @Override
-        public Connection apply(String uri) {
+        public Connection getConnection(String uri) {
             try {
                 return DriverManager.getConnection(uri);
             } catch (SQLException e) {
                 throw propagate(e);
             }
         }
+
+        @Override
+        public Connection getConnection(String uri, String username, String password) {
+            try {
+                return DriverManager.getConnection(uri, username, password);
+            } catch (SQLException e) {
+                throw propagate(e);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    interface UriConnectionProvider {
+        Connection getConnection(String uri);
+        Connection getConnection(String uri, String username, String password);
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByUri.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByUri.java
@@ -29,37 +29,37 @@ public class ConnectionConfigurationByUri implements ConnectionConfiguration {
     private final String uri;
     private final Optional<String> username;
     private final Optional<String> password;
-    private final UriConnectionProvider connectionProvider;
+    private final UriConnectionSupplier connectionSupplier;
 
     public ConnectionConfigurationByUri(String uri,
                                         Optional<String> username,
                                         Optional<String> password) {
 
-        this(uri, username, password, DefaultUriConnectionProvider.INSTANCE);
+        this(uri, username, password, DefaultUriConnectionSupplier.INSTANCE);
     }
 
     @VisibleForTesting
     ConnectionConfigurationByUri(String uri,
                                  Optional<String> username,
                                  Optional<String> password,
-                                 UriConnectionProvider connectionProvider) {
+                                 UriConnectionSupplier connectionSupplier) {
 
         this.uri = uri;
         this.username = username;
         this.password = password;
-        this.connectionProvider = connectionProvider;
+        this.connectionSupplier = connectionSupplier;
     }
 
     @Override
     public Connection get() {
         if (username.isPresent()) {
-            return connectionProvider.getConnection(uri, username.get(), password.or(""));
+            return connectionSupplier.getConnection(uri, username.get(), password.or(""));
         }
-        return connectionProvider.getConnection(uri);
+        return connectionSupplier.getConnection(uri);
 
     }
 
-    private enum DefaultUriConnectionProvider implements UriConnectionProvider {
+    private enum DefaultUriConnectionSupplier implements UriConnectionSupplier {
         INSTANCE;
 
         @Override
@@ -82,7 +82,7 @@ public class ConnectionConfigurationByUri implements ConnectionConfiguration {
     }
 
     @VisibleForTesting
-    interface UriConnectionProvider {
+    interface UriConnectionSupplier {
         Connection getConnection(String uri);
         Connection getConnection(String uri, String username, String password);
     }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByUriTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByUriTest.java
@@ -15,12 +15,12 @@
  */
 package org.liquigraph.core.configuration;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.liquigraph.core.configuration.ConnectionConfigurationByUri.UriConnectionProvider;
 
 import java.sql.Connection;
 
@@ -41,7 +41,7 @@ public class ConnectionConfigurationByUriTest {
                 "jdbc:neo4j:mem:mydb",
                 Optional.<String>absent(),
                 Optional.<String>absent(),
-                new MockedConnectionFunction(expectedConnection)
+                new MockedConnectionProvider(expectedConnection)
         );
 
         Connection connection = connectionProvider.get();
@@ -56,7 +56,7 @@ public class ConnectionConfigurationByUriTest {
             "jdbc:neo4j:mem:mydb",
             Optional.<String>absent(),
             Optional.<String>absent(),
-            new ThrowingConnectionFunction(failure)
+            new ThrowingConnectionProvider(failure)
         );
 
         thrown.expect(sameInstance(failure));
@@ -65,28 +65,38 @@ public class ConnectionConfigurationByUriTest {
 
     }
 
-    private static class ThrowingConnectionFunction implements Function<String, Connection> {
+    private static class ThrowingConnectionProvider implements UriConnectionProvider {
         private final RuntimeException exception;
 
-        public ThrowingConnectionFunction(RuntimeException exception) {
+        public ThrowingConnectionProvider(RuntimeException exception) {
             this.exception = exception;
         }
 
         @Override
-        public Connection apply(String s) {
+        public Connection getConnection(String uri) {
+            throw exception;
+        }
+
+        @Override
+        public Connection getConnection(String uri, String username, String password) {
             throw exception;
         }
     }
 
-    private static class MockedConnectionFunction implements Function<String, Connection> {
+    private static class MockedConnectionProvider implements UriConnectionProvider {
         private final Connection connection;
 
-        public MockedConnectionFunction(Connection connection) {
+        public MockedConnectionProvider(Connection connection) {
             this.connection = connection;
         }
 
         @Override
-        public Connection apply(String ignored) {
+        public Connection getConnection(String uri) {
+            return connection;
+        }
+
+        @Override
+        public Connection getConnection(String uri, String username, String password) {
             return connection;
         }
     }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByUriTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByUriTest.java
@@ -20,7 +20,7 @@ import com.google.common.base.Supplier;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.liquigraph.core.configuration.ConnectionConfigurationByUri.UriConnectionProvider;
+import org.liquigraph.core.configuration.ConnectionConfigurationByUri.UriConnectionSupplier;
 
 import java.sql.Connection;
 
@@ -41,7 +41,7 @@ public class ConnectionConfigurationByUriTest {
                 "jdbc:neo4j:mem:mydb",
                 Optional.<String>absent(),
                 Optional.<String>absent(),
-                new MockedConnectionProvider(expectedConnection)
+                new MockedConnectionSupplier(expectedConnection)
         );
 
         Connection connection = connectionProvider.get();
@@ -56,7 +56,7 @@ public class ConnectionConfigurationByUriTest {
             "jdbc:neo4j:mem:mydb",
             Optional.<String>absent(),
             Optional.<String>absent(),
-            new ThrowingConnectionProvider(failure)
+            new ThrowingConnectionSupplier(failure)
         );
 
         thrown.expect(sameInstance(failure));
@@ -65,10 +65,10 @@ public class ConnectionConfigurationByUriTest {
 
     }
 
-    private static class ThrowingConnectionProvider implements UriConnectionProvider {
+    private static class ThrowingConnectionSupplier implements UriConnectionSupplier {
         private final RuntimeException exception;
 
-        public ThrowingConnectionProvider(RuntimeException exception) {
+        public ThrowingConnectionSupplier(RuntimeException exception) {
             this.exception = exception;
         }
 
@@ -83,10 +83,10 @@ public class ConnectionConfigurationByUriTest {
         }
     }
 
-    private static class MockedConnectionProvider implements UriConnectionProvider {
+    private static class MockedConnectionSupplier implements UriConnectionSupplier {
         private final Connection connection;
 
-        public MockedConnectionProvider(Connection connection) {
+        public MockedConnectionSupplier(Connection connection) {
             this.connection = connection;
         }
 


### PR DESCRIPTION
Due to a bug in the Neo4j JDBC driver, passwords containing '&' or ','
is parsed wrongly (even if they are been URL encoded). This will fix
support for passwords with '&', ',' and '%' when used with a JDBC URI.