### PR TITLE
Introduce parameterized query

### DIFF
--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogFileWriter.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogFileWriter.java
@@ -16,6 +16,8 @@
 package org.liquigraph.core.io;
 
 import org.liquigraph.core.model.Changeset;
+import org.liquigraph.core.model.Query;
+import org.liquigraph.core.model.SimpleQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,11 +29,15 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.lang.String.format;
 import static java.nio.file.Files.createFile;
 import static java.nio.file.Files.deleteIfExists;
 import static java.nio.file.StandardOpenOption.APPEND;
+import static java.util.stream.Collectors.joining;
 import static org.liquigraph.core.exception.Throwables.propagate;
 
 public class ChangelogFileWriter implements ChangelogWriter {
@@ -83,8 +89,17 @@ public class ChangelogFileWriter implements ChangelogWriter {
         Collection<String> lines = new ArrayList<>();
         lines.add(format("//Liquigraph changeset[author: %s, id: %s]", changeset.getAuthor(), changeset.getId()));
         lines.add(format("//Liquigraph changeset[executionContexts: %s]", flatten(changeset.getExecutionsContexts())));
-        lines.addAll(changeset.getQueries());
+        lines.addAll(changeset.getQueries().stream().map(ChangelogFileWriter::queryToString).collect(Collectors.toList()));
         return lines;
+    }
+
+    private static String queryToString(Query query) {
+        List<String> parameters = query.getParameters();
+        List<String> parameterDetails = IntStream.range(0, parameters.size())
+            .mapToObj(i -> String.format("%d: %s", i + 1, parameters.get(i)))
+            .collect(Collectors.toList());
+        String wrappedParameters = parameters.isEmpty() ? "" : String.format(" // {%s}", String.join(", ", parameterDetails));
+        return String.format("%s%s", query.getQuery(), wrappedParameters);
     }
 
     private String flatten(Collection<String> executionsContexts) {
@@ -94,4 +109,7 @@ public class ChangelogFileWriter implements ChangelogWriter {
         return String.join(",", executionsContexts);
     }
 
+    public static void main(String[] args) {
+        System.out.println(queryToString(new SimpleQuery("MATCH (n) RETURN n")));
+    }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
@@ -16,6 +16,8 @@
 package org.liquigraph.core.io;
 
 import org.liquigraph.core.model.Changeset;
+import org.liquigraph.core.model.Query;
+import org.liquigraph.core.model.SimpleQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,10 +27,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableCollection;
+import static java.util.stream.Collectors.toList;
 import static org.liquigraph.core.exception.Throwables.propagate;
 
 public class ChangelogGraphReader {
@@ -97,7 +102,7 @@ public class ChangelogGraphReader {
         return changeset;
     }
 
-    private Collection<String> adaptQueries(Object rawQuery) {
-        return unmodifiableCollection((Collection<String>) rawQuery);
+    private List<Query> adaptQueries(Object rawQuery) {
+        return ((Collection<String>) rawQuery).stream().map(SimpleQuery::new).collect(toList());
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionExecutor.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionExecutor.java
@@ -16,10 +16,10 @@
 package org.liquigraph.core.io;
 
 import org.liquigraph.core.exception.ConditionExecutionException;
-import org.liquigraph.core.model.CompoundQuery;
+import org.liquigraph.core.model.CompoundConditionQuery;
 import org.liquigraph.core.model.Condition;
-import org.liquigraph.core.model.Query;
-import org.liquigraph.core.model.SimpleQuery;
+import org.liquigraph.core.model.ConditionQuery;
+import org.liquigraph.core.model.SimpleConditionQuery;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,13 +41,13 @@ public class ConditionExecutor {
         return applyPrecondition(connection, condition.getQuery());
     }
 
-    private boolean applyPrecondition(Connection connection, Query query) {
-        if (query instanceof SimpleQuery) {
-            SimpleQuery simpleQuery = (SimpleQuery) query;
+    private boolean applyPrecondition(Connection connection, ConditionQuery query) {
+        if (query instanceof SimpleConditionQuery) {
+            SimpleConditionQuery simpleQuery = (SimpleConditionQuery) query;
             return execute(connection, simpleQuery.getQuery());
         }
-        if (query instanceof CompoundQuery) {
-            CompoundQuery compoundQuery = (CompoundQuery) query;
+        if (query instanceof CompoundConditionQuery) {
+            CompoundConditionQuery compoundQuery = (CompoundConditionQuery) query;
             return compoundQuery.compose(
                 applyPrecondition(connection, compoundQuery.getFirstQuery()),
                 applyPrecondition(connection, compoundQuery.getSecondQuery())

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionPrinter.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionPrinter.java
@@ -15,11 +15,11 @@
  */
 package org.liquigraph.core.io;
 
-import org.liquigraph.core.model.CompoundQuery;
+import org.liquigraph.core.model.CompoundConditionQuery;
 import org.liquigraph.core.model.Condition;
 import org.liquigraph.core.model.Precondition;
-import org.liquigraph.core.model.Query;
-import org.liquigraph.core.model.SimpleQuery;
+import org.liquigraph.core.model.ConditionQuery;
+import org.liquigraph.core.model.SimpleConditionQuery;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,12 +46,12 @@ public class ConditionPrinter {
         return singletonList(traverseQuery(precondition.getQuery()));
     }
 
-    private String traverseQuery(Query query) {
-        if (query instanceof SimpleQuery) {
-            return ((SimpleQuery) query).getQuery();
+    private String traverseQuery(ConditionQuery query) {
+        if (query instanceof SimpleConditionQuery) {
+            return ((SimpleConditionQuery) query).getQuery();
         }
-        if (query instanceof CompoundQuery) {
-            CompoundQuery compoundQuery = (CompoundQuery) query;
+        if (query instanceof CompoundConditionQuery) {
+            CompoundConditionQuery compoundQuery = (CompoundConditionQuery) query;
             return compoundQuery.compose(
                 traverseQuery(compoundQuery.getFirstQuery()),
                 traverseQuery(compoundQuery.getSecondQuery())

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ChangelogParser.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ChangelogParser.java
@@ -70,12 +70,12 @@ public final class ChangelogParser {
             throw new IllegalArgumentException(format("Unable to parse changelog <%s>.", masterChangelog), e);
         }
     }
-
     /*
      * Ugly workaround due to the way JAXB handles setters
      * The checksum invariant of changesets cannot be properly
      * managed.
      */
+
     private void fixUpChangesets(Changelog changelog) {
         for (Changeset changeset : changelog.getChangesets()) {
             changeset.setQueries(changeset.getQueries());

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/AndConditionQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/AndConditionQuery.java
@@ -24,47 +24,47 @@ import java.util.List;
 import java.util.Objects;
 
 import static java.lang.String.format;
-import static org.liquigraph.core.model.CompoundQueries.checkQueryListState;
+import static org.liquigraph.core.model.CompoundConditionQueries.checkQueryListState;
 
-@XmlSeeAlso(Query.class)
-@XmlRootElement(name = "or")
-public class OrQuery implements CompoundQuery {
+@XmlSeeAlso(ConditionQuery.class)
+@XmlRootElement(name = "and")
+public class AndConditionQuery implements CompoundConditionQuery {
 
-    private List<Query> queries = new ArrayList<>();
+    private List<ConditionQuery> queries = new ArrayList<>();
 
     @XmlElementRefs({
-        @XmlElementRef(name = "and", type = AndQuery.class),
-        @XmlElementRef(name = "or", type = OrQuery.class),
-        @XmlElementRef(name = "query", type = SimpleQuery.class)
+        @XmlElementRef(name = "and", type = AndConditionQuery.class),
+        @XmlElementRef(name = "or", type = OrConditionQuery.class),
+        @XmlElementRef(name = "query", type = SimpleConditionQuery.class)
     })
-    public List<Query> getQueries() {
+    public List<ConditionQuery> getQueries() {
         return queries;
     }
 
-    public void setQueries(List<Query> queries) {
+    public void setQueries(List<ConditionQuery> queries) {
         this.queries = queries;
     }
 
     @Override
-    public Query getFirstQuery() {
+    public ConditionQuery getFirstQuery() {
         checkQueryListState(queries);
         return queries.get(0);
     }
 
     @Override
-    public Query getSecondQuery() {
+    public ConditionQuery getSecondQuery() {
         checkQueryListState(queries);
         return queries.get(1);
     }
 
     @Override
     public boolean compose(boolean firstResult, boolean secondResult) {
-        return firstResult || secondResult;
+        return firstResult && secondResult;
     }
 
     @Override
     public String compose(String firstQuery, String secondQuery) {
-        return format("((%s) OR (%s))", firstQuery, secondQuery);
+        return format("((%s) AND (%s))", firstQuery, secondQuery);
     }
 
     @Override
@@ -80,12 +80,12 @@ public class OrQuery implements CompoundQuery {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final OrQuery other = (OrQuery) obj;
+        final AndConditionQuery other = (AndConditionQuery) obj;
         return Objects.equals(this.queries, other.queries);
     }
 
     @Override
     public String toString() {
-        return format("<%s> OR <%s>", getFirstQuery(), getSecondQuery());
+        return format("<%s> AND <%s>", getFirstQuery(), getSecondQuery());
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Changeset.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Changeset.java
@@ -17,10 +17,13 @@ package org.liquigraph.core.model;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlElementRefs;
 import javax.xml.bind.annotation.XmlTransient;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -31,7 +34,7 @@ public class Changeset {
 
     private String id;
     private String author;
-    private Collection<String> queries = new ArrayList<>();
+    private List<Query> queries = new ArrayList<>();
     private String checksum;
     private Collection<String> executionsContexts = new ArrayList<>();
     private boolean runOnChange;
@@ -57,14 +60,15 @@ public class Changeset {
         this.author = author;
     }
 
-    @XmlElement(name = "query", required = true)
-    public Collection<String> getQueries() {
+    @XmlElementRefs({
+        @XmlElementRef(type = SimpleQuery.class),
+        @XmlElementRef(type = ParameterizedQuery.class)
+    })
+    public List<Query> getQueries() {
         return queries;
     }
 
-    public void setQueries(Collection<String> queries) {
-        checkArgument(queries != null, "Queries cannot be null");
-        checkArgument(queries.size() > 0, "At least one query must be defined");
+    public void setQueries(List<Query> queries) {
         this.queries = queries;
         setChecksum(checksum(queries));
     }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Checksums.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Checksums.java
@@ -26,10 +26,13 @@ public class Checksums {
 
     private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
 
-    public static String checksum(Collection<String> queries) {
+    public static String checksum(Collection<Query> queries) {
         MessageDigest messageDigest = sha1MessageDigest();
-        for (String query : queries) {
-            messageDigest.update(query.getBytes(UTF_8));
+        for (Query query : queries) {
+            messageDigest.update(query.getQuery().getBytes(UTF_8));
+            query.getParameters().forEach((parameter) -> {
+                messageDigest.update(parameter.toString().getBytes(UTF_8));
+            });
         }
         return buildHexadecimalRepresentation(messageDigest.digest());
     }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/CompoundConditionQueries.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/CompoundConditionQueries.java
@@ -15,17 +15,13 @@
  */
 package org.liquigraph.core.model;
 
+import java.util.Collection;
 
-import javax.xml.bind.annotation.XmlSeeAlso;
-import java.util.Collections;
-import java.util.List;
+import static org.liquigraph.core.exception.Preconditions.checkState;
 
-@XmlSeeAlso({SimpleQuery.class, ParameterizedQuery.class})
-public interface Query {
+public class CompoundConditionQueries {
 
-    String getQuery();
-
-    default List<String> getParameters() {
-        return Collections.emptyList();
+    public static void checkQueryListState(Collection<ConditionQuery> queries) {
+        checkState(queries.size() == 2);
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/CompoundConditionQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/CompoundConditionQuery.java
@@ -15,13 +15,10 @@
  */
 package org.liquigraph.core.model;
 
-import java.util.Collection;
+public interface CompoundConditionQuery extends ConditionQuery {
 
-import static org.liquigraph.core.exception.Preconditions.checkState;
-
-public class CompoundQueries {
-
-    public static void checkQueryListState(Collection<Query> queries) {
-        checkState(queries.size() == 2);
-    }
+    ConditionQuery getFirstQuery();
+    ConditionQuery getSecondQuery();
+    boolean compose(boolean firstResult, boolean secondResult);
+    String compose(String firstQuery, String secondQuery);
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Condition.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Condition.java
@@ -16,5 +16,5 @@
 package org.liquigraph.core.model;
 
 public interface Condition {
-    Query getQuery();
+    ConditionQuery getQuery();
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/ConditionQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/ConditionQuery.java
@@ -15,10 +15,9 @@
  */
 package org.liquigraph.core.model;
 
-public interface CompoundQuery extends Query {
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlTransient;
 
-    Query getFirstQuery();
-    Query getSecondQuery();
-    boolean compose(boolean firstResult, boolean secondResult);
-    String compose(String firstQuery, String secondQuery);
-}
+@XmlTransient
+@XmlSeeAlso({SimpleConditionQuery.class, AndConditionQuery.class, OrConditionQuery.class})
+public interface ConditionQuery {}

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/OrConditionQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/OrConditionQuery.java
@@ -24,46 +24,47 @@ import java.util.List;
 import java.util.Objects;
 
 import static java.lang.String.format;
+import static org.liquigraph.core.model.CompoundConditionQueries.checkQueryListState;
 
-@XmlSeeAlso(Query.class)
-@XmlRootElement(name = "and")
-public class AndQuery implements CompoundQuery {
+@XmlSeeAlso(ConditionQuery.class)
+@XmlRootElement(name = "or")
+public class OrConditionQuery implements CompoundConditionQuery {
 
-    private List<Query> queries = new ArrayList<>();
+    private List<ConditionQuery> queries = new ArrayList<>();
 
     @XmlElementRefs({
-        @XmlElementRef(name = "and", type = AndQuery.class),
-        @XmlElementRef(name = "or", type = OrQuery.class),
-        @XmlElementRef(name = "query", type = SimpleQuery.class)
+        @XmlElementRef(name = "and", type = AndConditionQuery.class),
+        @XmlElementRef(name = "or", type = OrConditionQuery.class),
+        @XmlElementRef(name = "query", type = SimpleConditionQuery.class)
     })
-    public List<Query> getQueries() {
+    public List<ConditionQuery> getQueries() {
         return queries;
     }
 
-    public void setQueries(List<Query> queries) {
+    public void setQueries(List<ConditionQuery> queries) {
         this.queries = queries;
     }
 
     @Override
-    public Query getFirstQuery() {
-        CompoundQueries.checkQueryListState(queries);
+    public ConditionQuery getFirstQuery() {
+        checkQueryListState(queries);
         return queries.get(0);
     }
 
     @Override
-    public Query getSecondQuery() {
-        CompoundQueries.checkQueryListState(queries);
+    public ConditionQuery getSecondQuery() {
+        checkQueryListState(queries);
         return queries.get(1);
     }
 
     @Override
     public boolean compose(boolean firstResult, boolean secondResult) {
-        return firstResult && secondResult;
+        return firstResult || secondResult;
     }
 
     @Override
     public String compose(String firstQuery, String secondQuery) {
-        return format("((%s) AND (%s))", firstQuery, secondQuery);
+        return format("((%s) OR (%s))", firstQuery, secondQuery);
     }
 
     @Override
@@ -79,12 +80,12 @@ public class AndQuery implements CompoundQuery {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final AndQuery other = (AndQuery) obj;
+        final OrConditionQuery other = (OrConditionQuery) obj;
         return Objects.equals(this.queries, other.queries);
     }
 
     @Override
     public String toString() {
-        return format("<%s> AND <%s>", getFirstQuery(), getSecondQuery());
+        return format("<%s> OR <%s>", getFirstQuery(), getSecondQuery());
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/ParameterizedQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/ParameterizedQuery.java
@@ -15,50 +15,71 @@
  */
 package org.liquigraph.core.model;
 
+import org.liquigraph.core.exception.Preconditions;
 
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import java.util.List;
 import java.util.Objects;
 
-@XmlRootElement(name = "query")
-public class SimpleQuery implements Query {
+import static org.liquigraph.core.exception.Preconditions.checkArgument;
+
+@XmlRootElement(name = "parameterized-query")
+public class ParameterizedQuery implements Query {
 
     private String query;
 
-    public SimpleQuery() {}
+    private List<String> parameters;
 
-    // visible for testing
-    public SimpleQuery(String query) {
-        this.query = query;
+    public ParameterizedQuery() {
     }
 
-    @XmlValue
-    @Override
-    public String getQuery() {
-        return query;
+    // visible for testing
+    public ParameterizedQuery(String query, List<String> parameters) {
+        this.query = query;
+        this.parameters = parameters;
     }
 
     public void setQuery(String query) {
         this.query = query;
     }
 
+    @XmlElement(name = "query")
+    @Override
+    public String getQuery() {
+        return query;
+    }
+
+    public void setParameters(List<String> parameters) {
+        this.parameters = parameters;
+    }
+
+    @XmlElement(name = "parameter")
+    @Override
+    public List<String> getParameters() {
+        return parameters;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        SimpleQuery that = (SimpleQuery) o;
-        return Objects.equals(query, that.query);
+        ParameterizedQuery that = (ParameterizedQuery) o;
+        return Objects.equals(query, that.query) &&
+        Objects.equals(parameters, that.parameters);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(query);
+        return Objects.hash(query, parameters);
     }
 
     @Override
     public String toString() {
-        return "SimpleQuery{" +
+        return "ParameterizedQuery{" +
         "query='" + query + '\'' +
+        ", parameters=" + parameters +
         '}';
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Precondition.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Precondition.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 public class Precondition implements Condition {
 
     private PreconditionErrorPolicy policy;
-    private Query query;
+    private ConditionQuery query;
 
     @XmlAttribute(name = "if-not-met", required = true)
     public PreconditionErrorPolicy getPolicy() {
@@ -36,16 +36,16 @@ public class Precondition implements Condition {
     }
 
     @XmlElementRefs({
-        @XmlElementRef(name = "and", type = AndQuery.class),
-        @XmlElementRef(name = "or", type = OrQuery.class),
-        @XmlElementRef(name = "query", type = SimpleQuery.class)
+        @XmlElementRef(name = "and", type = AndConditionQuery.class),
+        @XmlElementRef(name = "or", type = OrConditionQuery.class),
+        @XmlElementRef(name = "query", type = SimpleConditionQuery.class)
     })
     @Override
-    public Query getQuery() {
+    public ConditionQuery getQuery() {
         return query;
     }
 
-    public void setQuery(Query query) {
+    public void setQuery(ConditionQuery query) {
         this.query = query;
     }
 

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/SimpleConditionQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/SimpleConditionQuery.java
@@ -15,26 +15,25 @@
  */
 package org.liquigraph.core.model;
 
-
-import javax.xml.bind.annotation.XmlElementRef;
-import javax.xml.bind.annotation.XmlElementRefs;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlValue;
 import java.util.Objects;
 
-public class Postcondition implements Condition {
+import static java.lang.String.format;
 
-    private ConditionQuery query;
+@XmlSeeAlso(ConditionQuery.class)
+@XmlRootElement(name = "query")
+public class SimpleConditionQuery implements ConditionQuery {
 
-    @XmlElementRefs({
-        @XmlElementRef(name = "and", type = AndConditionQuery.class),
-        @XmlElementRef(name = "or", type = OrConditionQuery.class),
-        @XmlElementRef(name = "query", type = SimpleConditionQuery.class)
-    })
-    @Override
-    public ConditionQuery getQuery() {
+    private String query;
+
+    @XmlValue
+    public String getQuery() {
         return query;
     }
 
-    public void setQuery(ConditionQuery query) {
+    public void setQuery(String query) {
         this.query = query;
     }
 
@@ -51,14 +50,12 @@ public class Postcondition implements Condition {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Postcondition other = (Postcondition) obj;
+        final SimpleConditionQuery other = (SimpleConditionQuery) obj;
         return Objects.equals(this.query, other.query);
     }
 
     @Override
     public String toString() {
-        return "Postcondition{" +
-                "query='" + query + '\'' +
-                '}';
+        return format("<%s>", query);
     }
 }

--- a/liquigraph-core/src/main/resources/schema/changelog.xsd
+++ b/liquigraph-core/src/main/resources/schema/changelog.xsd
@@ -17,16 +17,23 @@
 
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:simpleType name="QueryType">
+    <xs:simpleType name="SimpleQueryType">
         <xs:restriction base="xs:string" />
     </xs:simpleType>
+
+    <xs:complexType name="ParameterizedQueryType">
+        <xs:sequence>
+            <xs:element name="query" type="SimpleQueryType" minOccurs="1" maxOccurs="1" />
+            <xs:element name="parameter" type="xs:anyType" minOccurs="1" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
 
     <xs:complexType name="ConditionChildType">
         <xs:sequence>
             <xs:choice minOccurs="1" maxOccurs="unbounded">
                 <xs:element name="and" type="ConditionChildType" minOccurs="0" />
                 <xs:element name="or" type="ConditionChildType" minOccurs="0" />
-                <xs:element name="query" type="QueryType" minOccurs="0" />
+                <xs:element name="query" type="SimpleQueryType" minOccurs="0" />
             </xs:choice>
         </xs:sequence>
     </xs:complexType>
@@ -36,7 +43,7 @@
             <xs:choice minOccurs="1" maxOccurs="1">
                 <xs:element name="and" type="ConditionChildType" minOccurs="0" />
                 <xs:element name="or" type="ConditionChildType" minOccurs="0" />
-                <xs:element name="query" type="QueryType" minOccurs="0" />
+                <xs:element name="query" type="SimpleQueryType" minOccurs="0" />
             </xs:choice>
         </xs:sequence>
 
@@ -48,7 +55,7 @@
             <xs:choice minOccurs="1" maxOccurs="1">
                 <xs:element name="and" type="ConditionChildType" minOccurs="0" />
                 <xs:element name="or" type="ConditionChildType" minOccurs="0" />
-                <xs:element name="query" type="QueryType" minOccurs="0" />
+                <xs:element name="query" type="SimpleQueryType" minOccurs="0" />
             </xs:choice>
         </xs:sequence>
     </xs:complexType>
@@ -60,7 +67,10 @@
     <xs:complexType name="ChangesetType">
         <xs:sequence>
             <xs:element name="precondition" type="PreconditionType" minOccurs="0" maxOccurs="1" />
-            <xs:element name="query" type="QueryType" minOccurs="1" maxOccurs="unbounded" />
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="query" type="SimpleQueryType" minOccurs="0" />
+                <xs:element name="parameterized-query" type="ParameterizedQueryType" minOccurs="0" />
+            </xs:choice>
             <xs:element name="postcondition" type="PostconditionType" minOccurs="0" maxOccurs="1" />
         </xs:sequence>
 

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/ChangelogDiffMakerTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/ChangelogDiffMakerTest.java
@@ -18,6 +18,7 @@ package org.liquigraph.core.api;
 import org.junit.Test;
 import org.liquigraph.core.configuration.ExecutionContexts;
 import org.liquigraph.core.model.Changeset;
+import org.liquigraph.core.model.SimpleQuery;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -208,7 +209,7 @@ public class ChangelogDiffMakerTest {
         Changeset changeset = new Changeset();
         changeset.setId(id);
         changeset.setAuthor(author);
-        changeset.setQueries(singletonList(query));
+        changeset.setQueries(singletonList(new SimpleQuery(query)));
         return changeset;
     }
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionExecutorTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionExecutorTestSuite.java
@@ -20,12 +20,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.liquigraph.core.GraphIntegrationTestSuite;
 import org.liquigraph.core.exception.ConditionExecutionException;
-import org.liquigraph.core.model.AndQuery;
-import org.liquigraph.core.model.OrQuery;
+import org.liquigraph.core.model.AndConditionQuery;
+import org.liquigraph.core.model.OrConditionQuery;
 import org.liquigraph.core.model.Precondition;
 import org.liquigraph.core.model.PreconditionErrorPolicy;
-import org.liquigraph.core.model.Query;
-import org.liquigraph.core.model.SimpleQuery;
+import org.liquigraph.core.model.ConditionQuery;
+import org.liquigraph.core.model.SimpleConditionQuery;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -87,7 +87,7 @@ public abstract class ConditionExecutorTestSuite implements GraphIntegrationTest
 
     @Test
     public void executes_nested_mixed_precondition_queries_like_a_charm() throws SQLException {
-        AndQuery andQuery = new AndQuery();
+        AndConditionQuery andQuery = new AndConditionQuery();
         andQuery.setQueries(Arrays.asList(
             orPreconditionQuery("RETURN false AS result", "RETURN true AS result"),
             simplePreconditionQuery("RETURN true AS result")
@@ -147,7 +147,7 @@ public abstract class ConditionExecutorTestSuite implements GraphIntegrationTest
         thrown.expectMessage("Unsupported query type <org.liquigraph.core.io.ConditionExecutorTestSuite$1>");
 
         Precondition precondition = new Precondition();
-        precondition.setQuery(new Query() {
+        precondition.setQuery(new ConditionQuery() {
         });
         try (Connection connection = graphDatabase().newConnection()) {
             executor.executeCondition(connection, precondition);
@@ -166,34 +166,34 @@ public abstract class ConditionExecutorTestSuite implements GraphIntegrationTest
         return precondition(orPreconditionQuery(firstQuery, secondQuery));
     }
 
-    private AndQuery andPreconditionQuery(String firstQuery, String secondQuery) {
-        AndQuery andQuery = new AndQuery();
+    private AndConditionQuery andPreconditionQuery(String firstQuery, String secondQuery) {
+        AndConditionQuery andQuery = new AndConditionQuery();
         andQuery.setQueries(simpleQueries(firstQuery, secondQuery));
         return andQuery;
     }
 
-    private OrQuery orPreconditionQuery(String firstQuery, String secondQuery) {
-        OrQuery orQuery = new OrQuery();
+    private OrConditionQuery orPreconditionQuery(String firstQuery, String secondQuery) {
+        OrConditionQuery orQuery = new OrConditionQuery();
         orQuery.setQueries(simpleQueries(firstQuery, secondQuery));
         return orQuery;
     }
 
-    private List<Query> simpleQueries(String firstQuery, String secondQuery) {
+    private List<ConditionQuery> simpleQueries(String firstQuery, String secondQuery) {
         return Arrays.asList(
             simplePreconditionQuery(firstQuery),
             simplePreconditionQuery(secondQuery)
         );
     }
 
-    private Precondition precondition(Query query) {
+    private Precondition precondition(ConditionQuery query) {
         Precondition precondition = new Precondition();
         precondition.setPolicy(PreconditionErrorPolicy.MARK_AS_EXECUTED);
         precondition.setQuery(query);
         return precondition;
     }
 
-    private SimpleQuery simplePreconditionQuery(String query) {
-        SimpleQuery simpleQuery = new SimpleQuery();
+    private SimpleConditionQuery simplePreconditionQuery(String query) {
+        SimpleConditionQuery simpleQuery = new SimpleConditionQuery();
         simpleQuery.setQuery(query);
         return simpleQuery;
     }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionPrinterTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionPrinterTest.java
@@ -18,13 +18,13 @@ package org.liquigraph.core.io;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.liquigraph.core.model.AndQuery;
-import org.liquigraph.core.model.CompoundQuery;
-import org.liquigraph.core.model.OrQuery;
+import org.liquigraph.core.model.AndConditionQuery;
+import org.liquigraph.core.model.CompoundConditionQuery;
+import org.liquigraph.core.model.OrConditionQuery;
 import org.liquigraph.core.model.Precondition;
 import org.liquigraph.core.model.PreconditionErrorPolicy;
-import org.liquigraph.core.model.Query;
-import org.liquigraph.core.model.SimpleQuery;
+import org.liquigraph.core.model.ConditionQuery;
+import org.liquigraph.core.model.SimpleConditionQuery;
 
 import java.util.Arrays;
 
@@ -48,7 +48,7 @@ public class ConditionPrinterTest {
         thrown.expectMessage("Unsupported query type <org.liquigraph.core.io.ConditionPrinterTest$1>");
 
         Precondition precondition = new Precondition();
-        precondition.setQuery(new Query() {
+        precondition.setQuery(new ConditionQuery() {
         });
         conditionPrinter.print(precondition);
     }
@@ -88,27 +88,27 @@ public class ConditionPrinterTest {
                 "((FROM a RETURN a) OR (((FROM b RETURN b) AND (FROM c RETURN c))))");
     }
 
-    private Precondition precondition(Query query, PreconditionErrorPolicy aContinue) {
+    private Precondition precondition(ConditionQuery query, PreconditionErrorPolicy aContinue) {
         Precondition precondition = new Precondition();
         precondition.setQuery(query);
         precondition.setPolicy(aContinue);
         return precondition;
     }
 
-    private CompoundQuery orQuery(Query query1, Query query2) {
-        OrQuery orQuery = new OrQuery();
+    private CompoundConditionQuery orQuery(ConditionQuery query1, ConditionQuery query2) {
+        OrConditionQuery orQuery = new OrConditionQuery();
         orQuery.setQueries(Arrays.asList(query1, query2));
         return orQuery;
     }
 
-    private CompoundQuery andQuery(Query query1, Query query2) {
-        AndQuery andQuery = new AndQuery();
+    private CompoundConditionQuery andQuery(ConditionQuery query1, ConditionQuery query2) {
+        AndConditionQuery andQuery = new AndConditionQuery();
         andQuery.setQueries(Arrays.asList(query1, query2));
         return andQuery;
     }
 
-    private SimpleQuery simpleQuery(String query) {
-        SimpleQuery simpleQuery = new SimpleQuery();
+    private SimpleConditionQuery simpleQuery(String query) {
+        SimpleConditionQuery simpleQuery = new SimpleConditionQuery();
         simpleQuery.setQuery(query);
         return simpleQuery;
     }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/AndConditionQueryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/AndConditionQueryTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AndQueryTest {
+public class AndConditionQueryTest {
     @Test
     public void should_have_equality_on_queries() {
         assertThat(andQuery("MATCH (n) RETURN n", "MATCH(m) RETURN m"))
@@ -29,11 +29,11 @@ public class AndQueryTest {
             .isNotEqualTo(andQuery("MATCH (m) RETURN m", "MATCH(n) RETURN n"));
     }
 
-    private static AndQuery andQuery(String firstQuery, String secondQuery) {
-        AndQuery andQuery = new AndQuery();
-        SimpleQuery firstSimpleQuery = new SimpleQuery();
+    private static AndConditionQuery andQuery(String firstQuery, String secondQuery) {
+        AndConditionQuery andQuery = new AndConditionQuery();
+        SimpleConditionQuery firstSimpleQuery = new SimpleConditionQuery();
         firstSimpleQuery.setQuery(firstQuery);
-        SimpleQuery secondSimpleQuery = new SimpleQuery();
+        SimpleConditionQuery secondSimpleQuery = new SimpleConditionQuery();
         secondSimpleQuery.setQuery(secondQuery);
         andQuery.setQueries(Arrays.asList(firstSimpleQuery, secondSimpleQuery));
         return andQuery;

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/ChangesetTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/ChangesetTest.java
@@ -15,23 +15,32 @@
  */
 package org.liquigraph.core.model;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Unmarshaller;
+import java.io.StringReader;
 import java.util.Collections;
+import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChangesetTest {
 
+    @Ignore("not possible to prevent anymore with parameterized queries in the picture " +
+        "(@XmlElementRef(s) seems to call setters with default values first)")
     @Test(expected = IllegalArgumentException.class)
     public void should_fail_with_null_queries() {
         new Changeset().setQueries(null);
     }
 
+    @Ignore("not possible to prevent anymore with parameterized queries in the picture " +
+        "(@XmlElementRef(s) seems to call setters with default values first)")
     @Test(expected = IllegalArgumentException.class)
     public void should_fail_with_empty_queries() {
-        new Changeset().setQueries(Collections.<String>emptyList());
+        new Changeset().setQueries(Collections.emptyList());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -65,17 +74,17 @@ public class ChangesetTest {
     @Test
     public void should_have_equality_on_id_author_and_checksum() {
         assertThat(changeset("identifier", "author", "CREATE (n)"))
-            .isEqualTo(changeset("identifier", "author", "CREATE (n)"))
-            .isNotEqualTo(changeset("identifier", "author", "MATCH (n) RETURN n"))
-            .isNotEqualTo(changeset("identifier", "author2", "CREATE (n)"))
-            .isNotEqualTo(changeset("identifier2", "author", "CREATE (n)"));
+        .isEqualTo(changeset("identifier", "author", "CREATE (n)"))
+        .isNotEqualTo(changeset("identifier", "author", "MATCH (n) RETURN n"))
+        .isNotEqualTo(changeset("identifier", "author2", "CREATE (n)"))
+        .isNotEqualTo(changeset("identifier2", "author", "CREATE (n)"));
     }
 
     private Changeset changeset(String id, String author, String query) {
         Changeset changeset = new Changeset();
         changeset.setId(id);
         changeset.setAuthor(author);
-        changeset.setQueries(singletonList(query));
+        changeset.setQueries(singletonList(new SimpleQuery(query)));
         return changeset;
     }
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/ChecksumsTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/ChecksumsTest.java
@@ -17,7 +17,10 @@ package org.liquigraph.core.model;
 
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.liquigraph.core.model.Checksums.checksum;
 
@@ -25,7 +28,27 @@ public class ChecksumsTest {
 
     @Test
     public void computes_checksum_of_queries() {
-        assertThat(checksum(asList("MATCH (n) RETURN n", "MATCH (m) RETURN m")))
-            .isEqualTo("9c68d381cf24b9cab5843a506229c5dee1083f8e");
+        Query query1 = new SimpleQuery("MATCH (n) RETURN n");
+        Query query2 = new SimpleQuery("MATCH (m) RETURN m");
+        assertThat(checksum(asList(query1, query2))).isEqualTo("9c68d381cf24b9cab5843a506229c5dee1083f8e");
+    }
+
+    @Test
+    public void computes_checksum_of_parameterized_queries() {
+        Query query = new ParameterizedQuery("MATCH (n {name: {1}}) RETURN n", singletonList("some-name"));
+        assertThat(checksum(singletonList(query))).isEqualTo("a4785eefdb5f10e155648710bb0e26cb13941e7c");
+    }
+
+    @Test
+    public void avoids_checksum_collisions_of_differing_queries() {
+        Query query1 = new ParameterizedQuery("MATCH (n {name: {1}}) RETURN n", singletonList("some-name"));
+        Query query2 = new ParameterizedQuery("MATCH (n {name: {1}}) RETURN n", singletonList("some-name"));
+        Query query3 = new ParameterizedQuery("MATCH (m {name: {1}}) RETURN m", singletonList("some-name"));
+        Query query4 = new SimpleQuery("MATCH (n) RETURN n");
+
+        assertThat(checksum(singletonList(query1)))
+            .isEqualTo(checksum(singletonList(query2)))
+            .isNotEqualTo(checksum(singletonList(query3)))
+            .isNotEqualTo(checksum(singletonList(query4)));
     }
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/OrConditionQueryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/OrConditionQueryTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OrQueryTest {
+public class OrConditionQueryTest {
 
     @Test
     public void should_have_equality_on_queries() {
@@ -30,11 +30,11 @@ public class OrQueryTest {
             .isNotEqualTo(orQuery("MATCH (m) RETURN m", "MATCH(n) RETURN n"));
     }
 
-    private static OrQuery orQuery(String firstQuery, String secondQuery) {
-        OrQuery orQuery = new OrQuery();
-        SimpleQuery firstSimpleQuery = new SimpleQuery();
+    private static OrConditionQuery orQuery(String firstQuery, String secondQuery) {
+        OrConditionQuery orQuery = new OrConditionQuery();
+        SimpleConditionQuery firstSimpleQuery = new SimpleConditionQuery();
         firstSimpleQuery.setQuery(firstQuery);
-        SimpleQuery secondSimpleQuery = new SimpleQuery();
+        SimpleConditionQuery secondSimpleQuery = new SimpleConditionQuery();
         secondSimpleQuery.setQuery(secondQuery);
         orQuery.setQueries(Arrays.asList(firstSimpleQuery, secondSimpleQuery));
         return orQuery;

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/ParameterizedQueryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/ParameterizedQueryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.model;
+
+import org.junit.Test;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ParameterizedQueryTest {
+
+    @Test
+    public void equality_is_defined_on_query_and_parameters() {
+        Query query1 = new ParameterizedQuery("MATCH (n {name: {1}}) RETURN n", singletonList("something"));
+        Query query2 = new ParameterizedQuery("MATCH (n {name: {1}}) RETURN n", singletonList("something"));
+        Query query3 = new ParameterizedQuery("MATCH (o {name: {1}}) RETURN o", singletonList("something"));
+        Query query4 = new ParameterizedQuery("MATCH (n {name: {1}}) RETURN n", singletonList("something else"));
+
+        assertThat(query1)
+            .isEqualTo(query2)
+            .isNotEqualTo(query3)
+            .isNotEqualTo(query4);
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/PostconditionTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/PostconditionTest.java
@@ -29,7 +29,7 @@ public class PostconditionTest {
 
     private static Postcondition postcondition(String query) {
         Postcondition postcondition = new Postcondition();
-        SimpleQuery simpleQuery = new SimpleQuery();
+        SimpleConditionQuery simpleQuery = new SimpleConditionQuery();
         simpleQuery.setQuery(query);
         postcondition.setQuery(simpleQuery);
         return postcondition;

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/PreconditionTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/PreconditionTest.java
@@ -34,7 +34,7 @@ public class PreconditionTest {
     private static Precondition precondition(PreconditionErrorPolicy policy, String query) {
         Precondition precondition = new Precondition();
         precondition.setPolicy(policy);
-        SimpleQuery simpleQuery = new SimpleQuery();
+        SimpleConditionQuery simpleQuery = new SimpleConditionQuery();
         simpleQuery.setQuery(query);
         precondition.setQuery(simpleQuery);
         return precondition;

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/SimpleConditionQueryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/SimpleConditionQueryTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SimpleQueryTest {
+public class SimpleConditionQueryTest {
 
     @Test
     public void should_have_equality_on_query() {
@@ -28,8 +28,8 @@ public class SimpleQueryTest {
             .isNotEqualTo(simpleQuery("MATCH (m) RETURN m"));
     }
 
-    private static SimpleQuery simpleQuery(String query) {
-        SimpleQuery simpleQuery = new SimpleQuery();
+    private static SimpleConditionQuery simpleQuery(String query) {
+        SimpleConditionQuery simpleQuery = new SimpleConditionQuery();
         simpleQuery.setQuery(query);
         return simpleQuery;
     }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetByIdTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetByIdTest.java
@@ -17,6 +17,7 @@ package org.liquigraph.core.model.predicates;
 
 import org.junit.Test;
 import org.liquigraph.core.model.Changeset;
+import org.liquigraph.core.model.SimpleQuery;
 
 import java.util.function.Predicate;
 
@@ -62,7 +63,7 @@ public class ChangesetByIdTest {
         Changeset changeset = new Changeset();
         changeset.setId(id);
         changeset.setAuthor(author);
-        changeset.setQueries(singletonList(query));
+        changeset.setQueries(singletonList(new SimpleQuery(query)));
         return changeset;
     }
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChangedTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChangedTest.java
@@ -17,6 +17,7 @@ package org.liquigraph.core.model.predicates;
 
 import org.junit.Test;
 import org.liquigraph.core.model.Changeset;
+import org.liquigraph.core.model.SimpleQuery;
 
 import java.util.Collections;
 import java.util.function.Predicate;
@@ -55,7 +56,7 @@ public class ChangesetChecksumHasChangedTest {
         Changeset changeset = new Changeset();
         changeset.setId(id);
         changeset.setAuthor(author);
-        changeset.setQueries(singletonList(query));
+        changeset.setQueries(singletonList(new SimpleQuery(query)));
         return changeset;
     }
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/validation/PersistedChangesetValidatorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/validation/PersistedChangesetValidatorTest.java
@@ -17,6 +17,7 @@ package org.liquigraph.core.validation;
 
 import org.junit.Test;
 import org.liquigraph.core.model.Changeset;
+import org.liquigraph.core.model.SimpleQuery;
 
 import java.util.Collection;
 
@@ -72,8 +73,8 @@ public class PersistedChangesetValidatorTest {
                 "Changeset with ID <identifier> and author <author> has conflicted checksums.%n" +
                     "\t - Declared: <%s>%n" +
                     "\t - Persisted: <%s>.",
-                checksum(singletonList("MATCH m RETURN m")),
-                checksum(singletonList("MATCH (m)-->(z) RETURN m, z"))
+                checksum(singletonList(new SimpleQuery("MATCH m RETURN m"))),
+                checksum(singletonList(new SimpleQuery("MATCH (m)-->(z) RETURN m, z")))
             )
         );
     }
@@ -88,7 +89,7 @@ public class PersistedChangesetValidatorTest {
         Changeset changeset = new Changeset();
         changeset.setId(id);
         changeset.setAuthor(author);
-        changeset.setQueries(singletonList(query));
+        changeset.setQueries(singletonList(new SimpleQuery(query)));
         return changeset;
     }
 }

--- a/liquigraph-core/src/test/resources/changelog/invalid_changesets/changelog-with-parameterless-parameterized-queries.xml
+++ b/liquigraph-core/src/test/resources/changelog/invalid_changesets/changelog-with-parameterless-parameterized-queries.xml
@@ -17,13 +17,14 @@
 
 -->
 <changelog>
-    <changeset id="first-changelog" author="fbiville" contexts="foo,bar">
+    <changeset id='some_id' author="fbiville">
+        <parameterized-query>
+            <query>MATCH (n) WHERE n.name = {1}</query>
+            <parameter>some name</parameter>
+        </parameterized-query>
         <query>MATCH (n) RETURN n</query>
-    </changeset>
-    <changeset id="second-changelog" author="team" contexts="baz">
-        <query>MATCH (m) RETURN m</query>
-    </changeset>
-    <changeset id="third-changelog" author="team">
-        <query>MATCH (m) RETURN m</query>
+        <parameterized-query>
+            <query>MATCH (n) WHERE n.name = {1}</query>
+        </parameterized-query>
     </changeset>
 </changelog>

--- a/liquigraph-core/src/test/resources/changelog/parameterized_queries/changelog.xml
+++ b/liquigraph-core/src/test/resources/changelog/parameterized_queries/changelog.xml
@@ -17,13 +17,17 @@
 
 -->
 <changelog>
-    <changeset id="first-changelog" author="fbiville" contexts="foo,bar">
-        <query>MATCH (n) RETURN n</query>
-    </changeset>
-    <changeset id="second-changelog" author="team" contexts="baz">
-        <query>MATCH (m) RETURN m</query>
-    </changeset>
-    <changeset id="third-changelog" author="team">
-        <query>MATCH (m) RETURN m</query>
+    <changeset id='some_id' author="fbiville">
+        <query>CREATE (n:Person) RETURN n</query>
+        <parameterized-query>
+            <query>MATCH (n:Person) SET n.name = {1} RETURN n</query>
+            <parameter>some name</parameter>
+        </parameterized-query>
+        <query>CREATE (o:Place) RETURN o</query>
+        <parameterized-query>
+            <query>MATCH (o:Place) SET o.name = {1}, o.city = {2} RETURN o</query>
+            <parameter>some other name</parameter>
+            <parameter>some place</parameter>
+        </parameterized-query>
     </changeset>
 </changelog>


### PR DESCRIPTION
TODO
- make schema validation stricter, i.e. reject (same problem in
different places):
	- preconditions without queries
	- postcondition without queries
	- (new) changesets without queries
- support all types of parameters, not just String
- should we allow (pre|post)condition queries to be parameterized?