### PR TITLE
[#241] Allow offline usage of Liquigraph

### DIFF
--- a/liquigraph-core/pom.xml
+++ b/liquigraph-core/pom.xml
@@ -81,6 +81,12 @@
             <version>1.13.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.sniffy</groupId>
+            <artifactId>sniffy-junit</artifactId>
+            <version>3.1.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ChainedEntityResolver.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ChainedEntityResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io.xml;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public class ChainedEntityResolver implements EntityResolver {
+
+    private final List<EntityResolver> resolvers = new ArrayList<>();
+
+    public void addEntityResolver(final EntityResolver resolver) {
+        resolvers.add(resolver);
+    }
+
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+        for (EntityResolver entityResolver : resolvers) {
+            InputSource entity = entityResolver.resolveEntity(publicId, systemId);
+            if (entity != null) {
+                return entity;
+            }
+        }
+        return null;
+    }
+}

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ExplicitSchemaValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ExplicitSchemaValidator.java
@@ -48,7 +48,10 @@ class ExplicitSchemaValidator implements DomSourceValidator {
     public Collection<String> validate(DOMSource changelog) throws Exception {
         SchemaErrorHandler errorHandler = new SchemaErrorHandler();
         XMLReader reader = saxParser().getXMLReader();
-        reader.setEntityResolver(new RedirectAwareEntityResolver());
+        ChainedEntityResolver resolverChain = new ChainedEntityResolver();
+        resolverChain.addEntityResolver(new LiquigraphLocalEntityResolver());
+        resolverChain.addEntityResolver(new RedirectAwareEntityResolver());
+        reader.setEntityResolver(resolverChain);
         reader.setErrorHandler(errorHandler);
         parse(changelog, reader);
         return errorHandler.getErrors();

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ImplicitSchemaValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ImplicitSchemaValidator.java
@@ -15,6 +15,9 @@
  */
 package org.liquigraph.core.io.xml;
 
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSResourceResolver;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
@@ -25,6 +28,7 @@ import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.Collection;
 
 class ImplicitSchemaValidator implements DomSourceValidator {
@@ -50,8 +54,115 @@ class ImplicitSchemaValidator implements DomSourceValidator {
         }
     }
 
+    private static class InputSourceToLSInput implements LSInput {
+
+        private InputSource source;
+
+        private InputSourceToLSInput(InputSource source) {
+            this.source = source;
+        }
+
+        @Override
+        public Reader getCharacterStream() {
+            return source.getCharacterStream();
+        }
+
+        @Override
+        public void setCharacterStream(Reader characterStream) {
+            source.setCharacterStream(characterStream);
+        }
+
+        @Override
+        public InputStream getByteStream() {
+            return source.getByteStream();
+        }
+
+        @Override
+        public void setByteStream(InputStream byteStream) {
+            source.setByteStream(byteStream);
+        }
+
+        @Override
+        public String getStringData() {
+            return null;
+        }
+
+        @Override
+        public void setStringData(String stringData) {
+        }
+
+        @Override
+        public String getSystemId() {
+            return source.getSystemId();
+        }
+
+        @Override
+        public void setSystemId(String systemId) {
+            source.setSystemId(systemId);
+        }
+
+        @Override
+        public String getPublicId() {
+            return source.getPublicId();
+        }
+
+        @Override
+        public void setPublicId(String publicId) {
+            source.setPublicId(publicId);
+        }
+
+        @Override
+        public String getBaseURI() {
+            return null;
+        }
+
+        @Override
+        public void setBaseURI(String baseURI) {
+
+        }
+
+        @Override
+        public String getEncoding() {
+            return source.getEncoding();
+        }
+
+        @Override
+        public void setEncoding(String encoding) {
+            source.setEncoding(encoding);
+        }
+
+        @Override
+        public boolean getCertifiedText() {
+            return false;
+        }
+
+        @Override
+        public void setCertifiedText(boolean certifiedText) {
+        }
+
+    }
+
     private Validator validator(SchemaErrorHandler customErrorHandler) {
         Validator validator = schema.newValidator();
+        final ChainedEntityResolver resolverChain = new ChainedEntityResolver();
+        resolverChain.addEntityResolver(new LiquigraphLocalEntityResolver());
+        resolverChain.addEntityResolver(new RedirectAwareEntityResolver());
+        final LSResourceResolver currentResolver = validator.getResourceResolver();
+        validator.setResourceResolver(new LSResourceResolver() {
+            @Override
+            public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
+                try {
+                    InputSource input = resolverChain.resolveEntity(publicId, systemId);
+                    if (input != null) {
+                        return new InputSourceToLSInput(input);
+                    }
+                    return currentResolver.resolveResource(type, namespaceURI, publicId, systemId, baseURI);
+                }
+                catch (SAXException | IOException e) {
+                    throw new RuntimeException("Could not resolve with entity resolver", e);
+                }
+            }
+        });
         validator.setErrorHandler(customErrorHandler);
         return validator;
     }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/LiquigraphLocalEntityResolver.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/LiquigraphLocalEntityResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io.xml;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+/**
+ * Resolves XML entities against local classpath resources.
+ */
+public class LiquigraphLocalEntityResolver implements EntityResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final Map<String, String> KNOWN_ENTITIES = new HashMap<>();
+
+    static {
+        KNOWN_ENTITIES.put("http://www.liquigraph.org/schema/1.0/liquigraph.xsd", "schema/1.0/liquigraph.xsd");
+        KNOWN_ENTITIES.put("https://www.liquigraph.org/schema/1.0/liquigraph.xsd", "schema/1.0/liquigraph.xsd");
+        KNOWN_ENTITIES.put("http://liquigraph.github.io/schema/1.0/liquigraph.xsd", "schema/1.0/liquigraph.xsd");
+        KNOWN_ENTITIES.put("https://liquigraph.github.io/schema/1.0/liquigraph.xsd", "schema/1.0/liquigraph.xsd");
+        KNOWN_ENTITIES.put("http://fbiville.github.io/liquigraph/schema/1.0/liquigraph.xsd",
+        "schema/1.0/liquigraph.xsd");
+        KNOWN_ENTITIES.put("https://fbiville.github.io/liquigraph/schema/1.0/liquigraph.xsd",
+        "schema/1.0/liquigraph.xsd");
+        KNOWN_ENTITIES.put("http://www.liquigraph.org/schema/1.0-RC3/liquigraph.xsd", "schema/1.0-RC3/liquigraph.xsd");
+        KNOWN_ENTITIES.put("https://www.liquigraph.org/schema/1.0-RC3/liquigraph.xsd", "schema/1.0-RC3/liquigraph.xsd");
+        KNOWN_ENTITIES.put("http://fbiville.github.io/liquigraph/schema/1.0-RC3/liquigraph.xsd",
+        "schema/1.0-RC3/liquigraph.xsd");
+        KNOWN_ENTITIES.put("https://fbiville.github.io/liquigraph/schema/1.0-RC3/liquigraph.xsd",
+        "schema/1.0-RC3/liquigraph.xsd");
+        KNOWN_ENTITIES.put("http://www.liquigraph.org/schema/changelog.xsd", "schema/changelog.xsd");
+        KNOWN_ENTITIES.put("https://www.liquigraph.org/schema/changelog.xsd", "schema/changelog.xsd");
+    }
+
+    @Override
+    public InputSource resolveEntity(String publicId, final String systemId) {
+        LOGGER.trace("Resolving entity, public {}, system {}", publicId, systemId);
+        if (KNOWN_ENTITIES.containsKey(systemId)) {
+            return new InputSource(getClass().getClassLoader().getResourceAsStream(KNOWN_ENTITIES.get(systemId)));
+        }
+        return null;
+    }
+
+}

--- a/liquigraph-core/src/main/resources/schema/1.0-RC3/liquigraph.xsd
+++ b/liquigraph-core/src/main/resources/schema/1.0-RC3/liquigraph.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2014-2016 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:simpleType name="QueryType">
+        <xs:restriction base="xs:string" />
+    </xs:simpleType>
+
+    <xs:complexType name="PreconditionChildType">
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="and" type="PreconditionChildType" minOccurs="0" />
+                <xs:element name="or" type="PreconditionChildType" minOccurs="0" />
+                <xs:element name="query" type="QueryType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="PreconditionType">
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="1">
+                <xs:element name="and" type="PreconditionChildType" minOccurs="0" />
+                <xs:element name="or" type="PreconditionChildType" minOccurs="0" />
+                <xs:element name="query" type="QueryType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+
+        <xs:attribute name="if-not-met" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="ImportType">
+        <xs:attribute name="resource" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="ChangesetType">
+        <xs:sequence>
+            <xs:element name="precondition" type="PreconditionType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="query" type="QueryType" minOccurs="1" maxOccurs="unbounded" />
+        </xs:sequence>
+
+        <xs:attribute name="id" type="xs:string" use="required" />
+        <xs:attribute name="author" type="xs:string" use="required" />
+        <xs:attribute name="contexts" type="xs:string" use="optional" />
+        <xs:attribute name="run-always" type="xs:boolean" use="optional" />
+        <xs:attribute name="run-on-change" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:element name="changelog">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="import" type="ImportType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="changeset" type="ChangesetType" minOccurs="0" maxOccurs="unbounded" />
+            </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="unique_id">
+            <xs:selector xpath="changeset" />
+            <xs:field xpath="@id" />
+        </xs:unique>
+    </xs:element>
+</xs:schema>

--- a/liquigraph-core/src/main/resources/schema/1.0/liquigraph.xsd
+++ b/liquigraph-core/src/main/resources/schema/1.0/liquigraph.xsd
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2014-2016 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:simpleType name="QueryType">
+        <xs:restriction base="xs:string" />
+    </xs:simpleType>
+
+    <xs:complexType name="ConditionChildType">
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="and" type="ConditionChildType" minOccurs="0" />
+                <xs:element name="or" type="ConditionChildType" minOccurs="0" />
+                <xs:element name="query" type="QueryType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="PreconditionType">
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="1">
+                <xs:element name="and" type="ConditionChildType" minOccurs="0" />
+                <xs:element name="or" type="ConditionChildType" minOccurs="0" />
+                <xs:element name="query" type="QueryType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+
+        <xs:attribute name="if-not-met" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="PostconditionType">
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="1">
+                <xs:element name="and" type="ConditionChildType" minOccurs="0" />
+                <xs:element name="or" type="ConditionChildType" minOccurs="0" />
+                <xs:element name="query" type="QueryType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ImportType">
+        <xs:attribute name="resource" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="ChangesetType">
+        <xs:sequence>
+            <xs:element name="precondition" type="PreconditionType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="query" type="QueryType" minOccurs="1" maxOccurs="unbounded" />
+            <xs:element name="postcondition" type="PostconditionType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+
+        <xs:attribute name="id" type="xs:string" use="required" />
+        <xs:attribute name="author" type="xs:string" use="required" />
+        <xs:attribute name="contexts" type="xs:string" use="optional" />
+        <xs:attribute name="run-always" type="xs:boolean" use="optional" />
+        <xs:attribute name="run-on-change" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:element name="changelog">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="import" type="ImportType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="changeset" type="ChangesetType" minOccurs="0" maxOccurs="unbounded" />
+            </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="unique_id">
+            <xs:selector xpath="changeset" />
+            <xs:field xpath="@id" />
+        </xs:unique>
+    </xs:element>
+</xs:schema>

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/DomSourceValidatorFactoryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/DomSourceValidatorFactoryTest.java
@@ -39,7 +39,7 @@ public class DomSourceValidatorFactoryTest {
     public void instantiates_an_explicit_schema_validator_when_schema_is_set() throws Exception {
         String document =
                 "<changelog xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
-                "           xsi:noNamespaceSchemaLocation=\"http://liquigraph.org/schema/1.0-RC3/liquigraph.xsd\">\n" +
+                "           xsi:noNamespaceSchemaLocation=\"http://www.liquigraph.org/schema/1.0-RC3/liquigraph.xsd\">\n" +
                 "</changelog>";
         DomSourceValidator validator = factory.createValidator(domSource(document));
 

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/DomSources.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/DomSources.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io.xml;
+
+import java.io.ByteArrayInputStream;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.dom.DOMSource;
+
+import org.w3c.dom.Node;
+
+public class DomSources {
+
+    public static DOMSource domStringSource(String xml) throws Exception {
+        return new DOMSource(root(xml));
+    }
+
+    private static Node root(String xml) throws Exception {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(xml.getBytes())) {
+            return DocumentBuilderFactory
+            .newInstance()
+            .newDocumentBuilder()
+            .parse(inputStream)
+            .getDocumentElement();
+        }
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/ExplicitSchemaValidatorOfflineTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/ExplicitSchemaValidatorOfflineTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
+import static org.liquigraph.core.io.xml.DomSources.domStringSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collection;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.dom.DOMSource;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.w3c.dom.Node;
+
+import io.sniffy.socket.DisableSockets;
+import io.sniffy.test.junit.SniffyRule;
+
+public class ExplicitSchemaValidatorOfflineTest {
+
+    @Rule
+    public SniffyRule sniffyRule = new SniffyRule();
+
+    @Test
+    @DisableSockets
+    public void validates_document_with_no_internet_connection() throws Exception {
+        String document =
+                "<changelog xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
+                "           xsi:noNamespaceSchemaLocation=\"http://www.liquigraph.org/schema/1.0/liquigraph.xsd\">\n" +
+                "</changelog>";
+        ExplicitSchemaValidator validator = new ExplicitSchemaValidator();
+
+        Collection<String> errors = validator.validate(domStringSource(document));
+
+        assertThat(errors).isEmpty();
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/ImplicitSchemaValidatorOfflineTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/ImplicitSchemaValidatorOfflineTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.liquigraph.core.io.xml.DomSources.domStringSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collection;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.dom.DOMSource;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.w3c.dom.Node;
+
+import io.sniffy.socket.DisableSockets;
+import io.sniffy.test.junit.SniffyRule;
+
+public class ImplicitSchemaValidatorOfflineTest {
+
+    @Rule
+    public SniffyRule sniffyRule = new SniffyRule();
+
+    @Test
+    @DisableSockets
+    public void validates_document_with_no_internet_connection() throws Exception {
+        String document =
+                "<changelog>\n" +
+                "    <changeset id=\"hello-world\" author=\"you\">\n" +
+                "        <query>CREATE (n:Sentence {text:'Hello monde!'}) RETURN n</query>\n" +
+                "    </changeset>" +
+                "</changelog>";
+        ImplicitSchemaValidator validator = new ImplicitSchemaValidator();
+
+        Collection<String> errors = validator.validate(domStringSource(document));
+
+        assertThat(errors).isEmpty();
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/SchemaDetectorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/SchemaDetectorTest.java
@@ -33,7 +33,7 @@ public class SchemaDetectorTest {
         String document =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<changelog xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-            "           xsi:noNamespaceSchemaLocation=\"http://liquigraph.org/schema/1.0-RC3/liquigraph.xsd\">\n" +
+            "           xsi:noNamespaceSchemaLocation=\"http://www.liquigraph.org/schema/1.0-RC3/liquigraph.xsd\">\n" +
             "</changelog>";
 
         assertThat(detector.hasExplicitSchema(domSource(document))).isTrue();
@@ -45,7 +45,7 @@ public class SchemaDetectorTest {
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<!-- here is an awesome comment -->\n" +
             "<changelog xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
-            "           xsi:noNamespaceSchemaLocation=\"http://liquigraph.org/schema/1.0-RC3/liquigraph.xsd\">\n" +
+            "           xsi:noNamespaceSchemaLocation=\"http://www.liquigraph.org/schema/1.0-RC3/liquigraph.xsd\">\n" +
             "</changelog>";
 
         assertThat(detector.hasExplicitSchema(domSource(document))).isTrue();


### PR DESCRIPTION
This introduces a chained entity resolver which searches first the
local directory for known XSDs, and then delegate to the
online, redirect-aware resolver if not found.

The local resolver now just uses a lookup of fixed paths, to ensure
there could be no path traversal problems by using a dynamic lookup.