### PR TITLE
370-provide-database-name-in-configuration

### DIFF
--- a/liquigraph-cli/src/main/java/org/liquigraph/cli/LiquigraphCli.java
+++ b/liquigraph-cli/src/main/java/org/liquigraph/cli/LiquigraphCli.java
@@ -74,6 +74,12 @@ public class LiquigraphCli {
     private String graphDbUri;
 
     @Parameter(
+            names = {"--database", "-u"},
+            description = "Graph DB database (remote only)"
+    )
+    private String database;
+
+    @Parameter(
             names = {"--username", "-u"},
             description = "Graph DB username (remote only)"
     )
@@ -119,6 +125,7 @@ public class LiquigraphCli {
         ConfigurationBuilder builder = new ConfigurationBuilder()
                 .withMasterChangelogLocation(fileName(cli.changelog))
                 .withUri(cli.graphDbUri)
+                .withDatabase(cli.database)
                 .withUsername(cli.username)
                 .withPassword(cli.password)
                 .withExecutionContexts(executionContexts(cli.executionContexts))

--- a/liquigraph-cli/src/main/java/org/liquigraph/cli/LiquigraphCli.java
+++ b/liquigraph-cli/src/main/java/org/liquigraph/cli/LiquigraphCli.java
@@ -74,7 +74,7 @@ public class LiquigraphCli {
     private String graphDbUri;
 
     @Parameter(
-            names = {"--database", "-u"},
+            names = {"--database", "-db"},
             description = "Graph DB database (remote only)"
     )
     private String database;

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConfigurationBuilder.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConfigurationBuilder.java
@@ -212,7 +212,7 @@ public final class ConfigurationBuilder {
         errors.addAll(datasourceConnectionValidator.validate(uri, dataSource));
         errors.addAll(executionModeValidator.validate(executionMode));
         if (database.isPresent()) {
-            errors.addAll(userCredentialsOptionValidator.validateWithDatabase(username, password));
+            errors.addAll(userCredentialsOptionValidator.validate(username, password));
         }
         else {
             errors.addAll(userCredentialsOptionValidator.validate(username.orElse(null), password.orElse(null)));

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConfigurationBuilder.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConfigurationBuilder.java
@@ -90,7 +90,7 @@ public final class ConfigurationBuilder {
     /**
      * Specifies the database to run changes on.
      *
-     * @param database username
+     * @param database database
      * @return itself for chaining purposes
      */
     public ConfigurationBuilder withDatabase(String database) {

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByUri.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByUri.java
@@ -20,70 +20,72 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.liquigraph.core.exception.Throwables.propagate;
 
 public class ConnectionConfigurationByUri implements ConnectionConfiguration {
 
     private final String uri;
+    private final Properties properties;
+    private final Optional<String> database;
     private final Optional<String> username;
     private final Optional<String> password;
     private final UriConnectionSupplier connectionSupplier;
 
     public ConnectionConfigurationByUri(String uri,
+                                        Optional<String> database,
                                         Optional<String> username,
                                         Optional<String> password) {
 
-        this(uri, username, password, DefaultUriConnectionSupplier.INSTANCE);
+        this(uri, database, username, password, DefaultUriConnectionSupplier.INSTANCE);
     }
 
     // visible for testing
     ConnectionConfigurationByUri(String uri,
+                                 Optional<String> database,
                                  Optional<String> username,
                                  Optional<String> password,
                                  UriConnectionSupplier connectionSupplier) {
 
         this.uri = uri;
+        this.database = database;
         this.username = username;
         this.password = password;
         this.connectionSupplier = connectionSupplier;
+        this.properties = props();
     }
 
     @Override
     public Connection get() {
-        if (username.isPresent()) {
-            return connectionSupplier.getConnection(uri, username.get(), password.orElse(""));
-        }
-        return connectionSupplier.getConnection(uri);
+        return connectionSupplier.getConnection(uri, properties);
+    }
 
+
+    private Properties props() {
+        Properties props = new Properties();
+        username.ifPresent(user -> props.setProperty("user", user));
+        password.ifPresent(pw -> props.setProperty("password", pw));
+        props.setProperty("database", database.orElse("neo4j"));
+        return props;
     }
 
     private enum DefaultUriConnectionSupplier implements UriConnectionSupplier {
         INSTANCE;
 
         @Override
-        public Connection getConnection(String uri) {
+        public Connection getConnection(String uri, Properties properties) {
             try {
-                return DriverManager.getConnection(uri);
+                return DriverManager.getConnection(uri, properties);
             } catch (SQLException e) {
                 throw propagate(e);
             }
         }
 
-        @Override
-        public Connection getConnection(String uri, String username, String password) {
-            try {
-                return DriverManager.getConnection(uri, username, password);
-            } catch (SQLException e) {
-                throw propagate(e);
-            }
-        }
     }
 
     // visible for testing
     interface UriConnectionSupplier {
-        Connection getConnection(String uri);
-
-        Connection getConnection(String uri, String username, String password);
+        Connection getConnection(String uri, Properties properties);
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/UserCredentialsOptionValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/UserCredentialsOptionValidator.java
@@ -17,6 +17,7 @@ package org.liquigraph.core.configuration.validators;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 public class UserCredentialsOptionValidator {
 
@@ -32,8 +33,23 @@ public class UserCredentialsOptionValidator {
     public Collection<String> validate(String username, String password) {
         if (username != null ^ password != null) {
             return Collections.singletonList("Please provide both username and password, or none.");
-        } else {
+        }
+        return Collections.emptyList();
+    }
+
+
+    /**
+     * Validates the given user credentials are provided; username and password
+     *
+     * @param username the username to use to connect
+     * @param password the password corresponding to {@code username}
+     * @return a collection of Strings describing possible errors, an empty
+     * collection if no errors
+     */
+    public Collection<String> validateWithDatabase(Optional<String> username, Optional<String> password) {
+        if (username.isPresent() && password.isPresent()) {
             return Collections.emptyList();
         }
+        return Collections.singletonList("Please provide username and password when providing a database.");
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/UserCredentialsOptionValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/UserCredentialsOptionValidator.java
@@ -46,7 +46,7 @@ public class UserCredentialsOptionValidator {
      * @return a collection of Strings describing possible errors, an empty
      * collection if no errors
      */
-    public Collection<String> validateWithDatabase(Optional<String> username, Optional<String> password) {
+    public Collection<String> validate(Optional<String> username, Optional<String> password) {
         if (username.isPresent() && password.isPresent()) {
             return Collections.emptyList();
         }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/BoltGraphDatabaseRule.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/BoltGraphDatabaseRule.java
@@ -23,6 +23,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Properties;
 
 import org.junit.rules.ExternalResource;
 import org.liquigraph.core.exception.Throwables;
@@ -46,7 +47,7 @@ implements GraphDatabaseRule {
     @Override
     public Connection newConnection() {
         try {
-            Connection connection = DriverManager.getConnection(uri());
+            Connection connection = DriverManager.getConnection(uri(), props());
             connection.setAutoCommit(false);
             connections.add(connection);
             return connection;
@@ -61,6 +62,19 @@ implements GraphDatabaseRule {
         return "jdbc:neo4j:" + controls.boltURI() + "?noSsl";
     }
 
+    public Properties props() {
+        Properties props = new Properties();
+        username().ifPresent(user -> props.setProperty("user", user));
+        password().ifPresent(pw -> props.setProperty("password", pw));
+        props.setProperty("database", database().orElse("neo4j"));
+        return props;
+    }
+
+    @Override
+    public Optional<String> database() {
+        return Optional.empty();
+    }
+
     @Override
     public Optional<String> username() {
         return Optional.empty();
@@ -70,6 +84,7 @@ implements GraphDatabaseRule {
     public Optional<String> password() {
         return Optional.empty();
     }
+
 
     protected void before() {
         controls = builder.build();

--- a/liquigraph-core/src/test/java/org/liquigraph/core/GraphDatabaseRule.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/GraphDatabaseRule.java
@@ -24,6 +24,7 @@ public interface GraphDatabaseRule extends TestRule {
 
     Connection newConnection();
     String uri();
+    Optional<String> database();
     Optional<String> username();
     Optional<String> password();
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/HttpGraphDatabaseRule.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/HttpGraphDatabaseRule.java
@@ -28,6 +28,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.liquigraph.core.exception.Throwables.propagate;
@@ -36,12 +37,14 @@ public class HttpGraphDatabaseRule extends ExternalResource
     implements GraphDatabaseRule {
 
     private final String uri;
+    private final String database;
     private final String username;
     private final String password;
     private final Collection<Connection> connections = new ArrayList<>();
 
     public HttpGraphDatabaseRule() {
         uri = "jdbc:neo4j:http://localhost:7474";
+        database = "neo4j";
         username = "neo4j";
         password = "j4oen";
     }
@@ -62,7 +65,7 @@ public class HttpGraphDatabaseRule extends ExternalResource
     @Override
     public Connection newConnection() {
         try {
-            Connection connection = DriverManager.getConnection(uri, username, password);
+            Connection connection = DriverManager.getConnection(uri, props());
             connection.setAutoCommit(false);
             connections.add(connection);
             return connection;
@@ -74,6 +77,19 @@ public class HttpGraphDatabaseRule extends ExternalResource
     @Override
     public String uri() {
         return uri;
+    }
+
+    public Properties props() {
+        Properties props = new Properties();
+        props.setProperty("database", database);
+        props.setProperty("user", username);
+        props.setProperty("password", password);
+        return props;
+    }
+
+    @Override
+    public Optional<String> database() {
+        return Optional.of(database);
     }
 
     @Override

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConfigurationBuilderTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConfigurationBuilderTest.java
@@ -191,4 +191,44 @@ public class ConfigurationBuilderTest {
                 .withRunMode()
                 .build();
     }
+
+    @Test
+    public void should_use_default_database_if_database_not_provided() {
+        new ConfigurationBuilder()
+                .withMasterChangelogLocation("changelog/changelog.xml")
+                .withUri("jdbc:neo4j:http://localhost:7474")
+                .withUsername("steve")
+                .withPassword("password")
+                .withRunMode()
+                .build();
+    }
+
+    @Test
+    public void should_use_database_if_provided() {
+        new ConfigurationBuilder()
+                .withMasterChangelogLocation("changelog/changelog.xml")
+                .withUri("jdbc:neo4j:http://localhost:7474")
+                .withUsername("user")
+                .withPassword("pw")
+                .withDatabase("myDatabase")
+                .withRunMode()
+                .build();
+    }
+
+    @Test
+    public void fails_on_database_provided_without_username_and_password_provided() {
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Please provide username and password when providing a database.");
+
+        new ConfigurationBuilder()
+                .withMasterChangelogLocation("changelog/changelog.xml")
+                .withUri("jdbc:neo4j:http://localhost:7474")
+                .withDatabase("myDatabase")
+                .withUsername("myUser")
+                .withRunMode()
+                .build();
+    }
+
+
+
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByUriTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByUriTest.java
@@ -22,6 +22,7 @@ import org.liquigraph.core.configuration.ConnectionConfigurationByUri.UriConnect
 
 import java.sql.Connection;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +42,7 @@ public class ConnectionConfigurationByUriTest {
             "jdbc:neo4j:mem:mydb",
             Optional.<String>empty(),
             Optional.<String>empty(),
+            Optional.<String>empty(),
             new MockedConnectionSupplier(expectedConnection)
         );
 
@@ -54,6 +56,7 @@ public class ConnectionConfigurationByUriTest {
         RuntimeException failure = new RuntimeException("oopsie");
         Supplier<Connection> connectionProvider = new ConnectionConfigurationByUri(
             "jdbc:neo4j:mem:mydb",
+            Optional.<String>empty(),
             Optional.<String>empty(),
             Optional.<String>empty(),
             new ThrowingConnectionSupplier(failure)
@@ -73,14 +76,10 @@ public class ConnectionConfigurationByUriTest {
         }
 
         @Override
-        public Connection getConnection(String uri) {
+        public Connection getConnection(String uri, Properties properties) {
             throw exception;
         }
 
-        @Override
-        public Connection getConnection(String uri, String username, String password) {
-            throw exception;
-        }
     }
 
     private static class MockedConnectionSupplier implements UriConnectionSupplier {
@@ -91,13 +90,9 @@ public class ConnectionConfigurationByUriTest {
         }
 
         @Override
-        public Connection getConnection(String uri) {
+        public Connection getConnection(String uri, Properties properties) {
             return connection;
         }
 
-        @Override
-        public Connection getConnection(String uri, String username, String password) {
-            return connection;
-        }
     }
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorTestSuite.java
@@ -56,6 +56,7 @@ public abstract class GraphJdbcConnectorTestSuite implements GraphIntegrationTes
             .withRunMode()
             .withMasterChangelogLocation("changelog/changelog.xml")
             .withUri(graphDatabase.uri())
+            .withDatabase(graphDatabase.database().orElse(null))
             .withUsername(graphDatabase.username().orElse(null))
             .withPassword(graphDatabase.password().orElse(null))
             .build()

--- a/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/LiquigraphMojoBase.java
+++ b/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/LiquigraphMojoBase.java
@@ -55,6 +55,12 @@ public abstract class LiquigraphMojoBase extends AbstractMojo {
     String jdbcUri;
 
     /**
+     * Graph connection database.
+     */
+    @Parameter(property = "database")
+    String database;
+
+    /**
      * Graph connection username.
      */
     @Parameter(property = "username")
@@ -76,7 +82,7 @@ public abstract class LiquigraphMojoBase extends AbstractMojo {
     String executionContexts = "";
 
     @Override
-    public final void execute() throws MojoExecutionException, MojoFailureException {
+    public final void execute() throws MojoExecutionException {
         String directory = project.getBuild().getDirectory();
 
         try {
@@ -84,6 +90,7 @@ public abstract class LiquigraphMojoBase extends AbstractMojo {
                 .withClassLoader(ProjectClassLoader.getClassLoader(project))
                 .withExecutionContexts(executionContexts(executionContexts))
                 .withMasterChangelogLocation(changelog)
+                .withDatabase(database)
                 .withUsername(username)
                 .withPassword(password)
                 .withUri(jdbcUri))


### PR DESCRIPTION
Related to multiplate graph database now possible, we need a way to accept this in the configuration.
Default database is still "neo4j" if not provided

https://github.com/liquigraph/liquigraph/issues/370