### PR TITLE
Improve Robustness for Neo4j clusters

### DIFF
--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/Configuration.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/Configuration.java
@@ -90,14 +90,13 @@ public final class Configuration {
         return executionMode;
     }
 
-    public ChangelogWriter resolveWriter(Connection writeConnection,
-                                         Supplier<Connection> connectionSupplier,
+    public ChangelogWriter resolveWriter(Supplier<Connection> connectionSupplier,
                                          ConditionExecutor conditionExecutor,
                                          ConditionPrinter conditionPrinter) {
 
         ExecutionMode executionMode = executionMode();
         if (executionMode == RunMode.RUN_MODE) {
-            return new ChangelogGraphWriter(writeConnection, connectionSupplier, conditionExecutor);
+            return new ChangelogGraphWriter(connectionSupplier, conditionExecutor);
         }
         if (executionMode instanceof DryRunMode) {
             DryRunMode dryRunMode = (DryRunMode) executionMode;

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterIT.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterIT.java
@@ -46,7 +46,6 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
         graphDb
             .commitNewConnection(uri, connection -> {
                 ChangelogGraphWriter writer = new ChangelogGraphWriter(
-                connection,
                 graphDb.asConnectionSupplier(uri),
                 new ConditionExecutor());
 
@@ -78,7 +77,6 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
         graphDb
             .commitNewConnection(uri, connection -> {
                 ChangelogGraphWriter writer = new ChangelogGraphWriter(
-                connection,
                 graphDb.asConnectionSupplier(uri),
                 new ConditionExecutor());
                 Precondition precondition = precondition(PreconditionErrorPolicy.FAIL, "RETURN true AS result");
@@ -113,7 +111,6 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
         () -> {
             graphDb.commitNewConnection(uri, connection -> {
                 ChangelogGraphWriter writer = new ChangelogGraphWriter(
-                connection,
                 graphDb.asConnectionSupplier(uri),
                 new ConditionExecutor());
 
@@ -132,7 +129,6 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
         graphDb
             .commitNewConnection(uri, connection -> {
                 ChangelogGraphWriter writer = new ChangelogGraphWriter(
-                connection,
                 graphDb.asConnectionSupplier(uri),
                 new ConditionExecutor());
                 Precondition precondition = precondition(PreconditionErrorPolicy.CONTINUE, "RETURN false AS result");
@@ -156,7 +152,6 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
         graphDb
             .commitNewConnection(uri, connection -> {
                 ChangelogGraphWriter writer = new ChangelogGraphWriter(
-                connection,
                 graphDb.asConnectionSupplier(uri),
                 new ConditionExecutor());
                 Precondition precondition = precondition(PreconditionErrorPolicy.MARK_AS_EXECUTED, "RETURN false AS result");
@@ -191,7 +186,6 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
         graphDb
             .commitNewConnection(uri, connection -> {
                 ChangelogGraphWriter writer = new ChangelogGraphWriter(
-                connection,
                 graphDb.asConnectionSupplier(uri),
                 new ConditionExecutor());
                 Changeset changeset = changeset("id", "fbiville", asList("CREATE (n:Human) RETURN n", "MATCH (n:Human) SET n.age = 42 RETURN n"));
@@ -223,7 +217,6 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
         graphDb
             .commitNewConnection(uri, connection -> {
                 ChangelogGraphWriter writer = new ChangelogGraphWriter(
-                connection,
                 graphDb.asConnectionSupplier(uri),
                 new ConditionExecutor());
                 Changeset changeset = changeset("identifier", "fbiville",
@@ -264,7 +257,6 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
         graphDb
             .commitNewConnection(uri, connection -> {
                 ChangelogGraphWriter writer = new ChangelogGraphWriter(
-                connection,
                 graphDb.asConnectionSupplier(uri),
                 new ConditionExecutor());
 
@@ -311,7 +303,8 @@ public class ChangelogGraphWriterIT extends ParameterizedDatabaseIT {
                     "       (n)-[:IS_RELATED_TO]->(n3:OtherNode)");
             })
             .commitNewConnection(uri, connection -> {
-                ChangelogGraphWriter writer = new ChangelogGraphWriter(connection, graphDb.asConnectionSupplier(uri), new ConditionExecutor());
+                ChangelogGraphWriter writer = new ChangelogGraphWriter(
+                graphDb.asConnectionSupplier(uri), new ConditionExecutor());
                 Changeset changeset = changeset("identifier", "fbiville",
                 "MATCH (n:SomeNode)-[r:IS_RELATED_TO]->(n2) " +
                 "WITH n, r, n2 " +


### PR DESCRIPTION
* Improvement for #434 
* The cached writeConnection is replaced by acquiring "fresh" connections from the connection supplier