### PR TITLE
Update JDBC driver to include Netty fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <argLine>-Duser.language=en -Xmx1024m</argLine>
         <generateBackupPoms>false</generateBackupPoms>
         <spring-boot.version>2.5.2</spring-boot.version>
-        <neo4j-jdbc.version>4.0.3</neo4j-jdbc.version>
+        <neo4j-jdbc.version>4.0.4</neo4j-jdbc.version>
         <test-containers.version>1.15.3</test-containers.version>
     </properties>
 


### PR DESCRIPTION
This Netty fix allows CLI application to properly shut down
without any explicit driver close calls.

See https://github.com/neo4j-contrib/neo4j-jdbc/releases/tag/4.0.4
for details.